### PR TITLE
fix CompoundNBT methods

### DIFF
--- a/overrides/kubejs/server_scripts/bonkers_chemistry.js
+++ b/overrides/kubejs/server_scripts/bonkers_chemistry.js
@@ -130,10 +130,10 @@ function process(level, block, entity, face) {
         if (validTool.id.startsWith(magnet)) {
             if (!toProcess.equals("minecraft:basalt"))
                 return
-            let energy = validTool.tag.getInteger("Energy") - 80 * processAmount
+            let energy = validTool.tag.getInt("Energy") - 80 * processAmount
             if (energy < 0)
                 return
-            validTool.tag.setInteger("Energy", energy)
+            validTool.tag.putInt("Energy", energy)
             resultItem = "thermal:basalz_rod"
             particle = "flame"
         }
@@ -143,7 +143,7 @@ function process(level, block, entity, face) {
             let energy = validTool.tag.getDouble("internalCurrentPower") - 40 * processAmount
             if (energy < 0)
                 return
-            validTool.tag.setDouble("internalCurrentPower", energy)
+            validTool.tag.putDouble("internalCurrentPower", energy)
             resultItem = "thermal:blitz_rod"
             particle = "firework"
         }
@@ -153,7 +153,7 @@ function process(level, block, entity, face) {
             let energy = validTool.tag.getDouble("internalCurrentPower") - 80 * processAmount
             if (energy < 0)
                 return
-            validTool.tag.setDouble("internalCurrentPower", energy)
+            validTool.tag.putDouble("internalCurrentPower", energy)
             resultItem = "thermal:blizz_rod"
             particle = "spit"
         }


### PR DESCRIPTION
fixes:

 [18:43:31] [Server thread/ERROR] [KubeJS Server/]: Error occurred while handling event 'block.left_click': TypeError: Cannot find function getInteger in object {Augments:[{Count:0b,id:"minecraft:air"},{Count:0b,id:"minecraft:air"},{Count:0b,id:"minecraft:air"},{Count:0b,id:"minecraft:air"}],Energy:19000,Properties:{}}. (server_scripts:bonkers_chemistry.js#133)

Snowball throws:
[18:44:21] [Server thread/ERROR] [KubeJS Server/]: Error occurred while handling event 'block.left_click': TypeError: Cannot find function setDouble in object {internalCurrentPower:200000.0d}. (server_scripts:bonkers_chemistry.js#156)

Mote throws:
[18:44:51] [Server thread/ERROR] [KubeJS Server/]: Error occurred while handling event 'block.left_click': TypeError: Cannot find function setDouble in object {internalCurrentPower:8000.0d}. (server_scripts:bonkers_chemistry.js#146)