### PR TITLE
fix bug involving silver_plate_to_ingot recipe

### DIFF
--- a/overrides/kubejs/server_scripts/recipes.js
+++ b/overrides/kubejs/server_scripts/recipes.js
@@ -1204,6 +1204,8 @@ function unify(event) {
 	event.recipes.createPressing([TE('signalum_plate')], TE('signalum_ingot'))
 	event.recipes.createPressing([TE('constantan_plate')], TE('constantan_ingot'))
 
+  event.replaceInput({ id: TE('machines/smelter/smelter_silver_plate_to_ingot') }, TE('invar_ingot'), TE('silver_plate'))
+
 	let woodcutting = (mod, log, planks, slab) => {
 		event.recipes.createCutting([mod + ":stripped_" + log], mod + ":" + log).processingTime(50)
 		event.recipes.createCutting([Item.of(mod + ":" + planks, 6)], mod + ":stripped_" + log).processingTime(50)


### PR DESCRIPTION
 fix bug involving silver_plate_to_ingot recipe that allowed you to turn invar into silver

**Describe the PR**
Fixes the thermal:machines/smelter/smelter_silver_plate_to_ingot that normally allows you to smelt a silver plate into a silver ingot.
The issue was that all silver plates and ingots were replaced with invar ingots causing this recipe to allow you to smelt invar ingots into silver ingots.

**Screenshots**
Before fix:
![before](https://github.com/ThePansmith/CABIN/assets/150861277/cca9f8f3-a251-4634-82a4-cd2b52b756ae)
After fix:
![after](https://github.com/ThePansmith/CABIN/assets/150861277/2ea910b5-d49d-4b16-b4e9-a1aeaf37101f)
