### PR TITLE
Update create and add create central kitchen to the pack

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -362,7 +362,7 @@
          "required":true
       },
       {
-         "fileID":4762214,
+         "fileID":4835188,
          "projectID":328085,
          "required":true
       },
@@ -775,7 +775,13 @@
          "fileID":4569023,
          "projectID":564792,
          "required":true
-      }
+      },
+			{
+				"fileID":4838717,
+				"projectID":820977,
+				"required":true
+		 }
+			
    ],
    "manifestType":"minecraftModpack",
    "manifestVersion":1,

--- a/modlist.html
+++ b/modlist.html
@@ -74,6 +74,7 @@
 <li><a href="https://www.curseforge.com/projects/564792">Create: Alloyed (by MithrilBagels, spottytheturtle, FortressNebula)</a></li>
 <li><a href="https://www.curseforge.com/projects/669724">Create: Crystal Clear (by Cyvack)</a></li>
 <li><a href="https://www.curseforge.com/projects/494206">Create Chunkloading (by embeddedt)</a></li>
+<li><a href="https://www.curseforge.com/projects/820977">Create Central Kitchen (by DragonsPlus)</a></li>
 <li><a href="https://www.curseforge.com/projects/509285">Create Deco (by Talrey [Code] &amp; Kayladillo [Art])</a></li>
 <li><a href="https://www.curseforge.com/projects/856996">Cristel Lib (by Cristelknight999)</a></li>
 <li><a href="https://www.curseforge.com/projects/296676">Culinary Construct (Forge/Fabric/Quilt) (by C4)</a></li>

--- a/overrides/config/create_central_kitchen-common.toml
+++ b/overrides/config/create_central_kitchen-common.toml
@@ -1,0 +1,31 @@
+
+#.
+#Config for Automation related components
+[automation]
+	#.
+	#Whether allowing Deployers to perform Cutting Board Recipes
+	enableCuttingBoardDeploying = true
+	#.
+	#List of Block Entities that can be boosted when placed on Blaze Stove
+	boostingCookerList = ["farmersdelight:cooking_pot", "farmersdelight:skillet", "miners_delight:copper_pot"]
+
+#.
+#Config for Integration with other mods
+[integration]
+	#.
+	#Whether replacing vanilla and modded pies into Farmer's Delight style
+	#[@cui:RequiresReload:both]
+	enablePieOverhaul = true
+	#.
+	#Pie items in this list will not be included in pie overhaul
+	#[@cui:RequiresReload:both]
+	pieOverhaulBlackList = []
+	#.
+	#For harvester to function properly, turning on this support will cause the collision shape of the overweight crop block to disappear.
+	#[@cui:RequiresReload:server]
+	enableHarvesterSupportForOverweightFarming = true
+	#.
+	#For harvester to function properly, turning on this support will cause the collision shape of Coffee Bush and Tea Bush block to disappear.
+	#[@cui:RequiresReload:server]
+	enableHarvesterSupportForFarmersRespite = true
+

--- a/overrides/defaultconfigs/mantle-server.toml
+++ b/overrides/defaultconfigs/mantle-server.toml
@@ -1,0 +1,3 @@
+#Preferences for outputs from tags used in automatic compat in recipes
+tagPreferences = ["minecraft", "create", "alloyed", "createdeco", "createaddition", "create_dd", "thermal", "tconstruct", "tmechworks"]
+

--- a/overrides/defaultconfigs/solcarrot-server.toml
+++ b/overrides/defaultconfigs/solcarrot-server.toml
@@ -1,0 +1,37 @@
+#Compatability config
+#There are enough foods in the base pack to earn the first 10 hearts.
+#Then next 10 hearts will need addons like the create food addons and farmer's delight addons.
+
+[milestones]
+	#Number of hearts you start out with.
+	#Range: 0 ~ 1000
+	baseHearts = 10
+	#Number of hearts you gain for reaching a new milestone.
+	#Range: 0 ~ 1000
+	heartsPerMilestone = 1
+	#A list of numbers of unique foods you need to eat to unlock each milestone, in ascending order. Naturally, adding more milestones lets you earn more hearts.
+	milestones = [15, 30, 45, 60, 75, 95, 115, 135, 155, 175, 200, 220, 240, 260, 280, 300, 320, 340, 360, 380]
+
+[filtering]
+	#Foods in this list won't affect the player's health nor show up in the food book.
+	blacklist = [
+		"create_central_kitchen:incomplete_egg_sandwich", "create_central_kitchen:incomplete_chicken_sandwich",
+		"create_central_kitchen:incomplete_hamburger", "create_central_kitchen:incomplete_bacon_sandwich",
+		"create_central_kitchen:incomplete_mutton_wrap", "create_central_kitchen:incomplete_apple_pie",
+		"create_central_kitchen:incomplete_sweet_berry_cheesecake", "create_central_kitchen:incomplete_pumpkin_pie",
+		"create_central_kitchen:incomplete_cherry_pie", "create_central_kitchen:incomplete_truffle_pie",
+		"create_central_kitchen:incomplete_mulberry_pie", "create_central_kitchen:incomplete_chorus_fruit_pie",
+		"create_central_kitchen:incomplete_chorus_flower_pie"]
+
+	#When this list contains anything, the blacklist is ignored and instead only foods from here count.
+	whitelist = []
+	#The minimum hunger value foods need to provide in order to count for milestones, in half drumsticks.
+	#Range: 0 ~ 1000
+	minimumFoodValue = 1
+
+[miscellaneous]
+	#Whether or not to reset the food list on death, effectively losing all bonus hearts.
+	resetOnDeath = false
+	#If true, eating foods outside of survival mode (e.g. creative/adventure) is not tracked and thus does not contribute towards progression.
+	limitProgressionToSurvival = false
+

--- a/overrides/kubejs/server_scripts/compatibility.js
+++ b/overrides/kubejs/server_scripts/compatibility.js
@@ -15,18 +15,25 @@ onEvent('recipes', event => {
 			event.stonecutting(Item.of(id, amount), 'kubejs:'+ machinename + '_machine')
 	}
 	
-//	if (Platform.isLoaded('YourModID')) {                                    // Mod ID goes here
-//		machine('andesite','minecraft:dirt', 1)                              // Recipes without an additional item will be stonecutting (saw) recipes
-//		machine('copper','minecraft:dispenser', 2, 'minecraft:bow')          // Recipes with one are smithing table recipes
-//
-//      event.shapeless("create:creative_crate", "minecraft:redstone_ore")]) // If you have any other recipes, put them following the machine recipes
-//}                                     
+	//	if (Platform.isLoaded('YourModID')) {                                    // Mod ID goes here
+	//		machine('andesite','minecraft:dirt', 1)                              // Recipes without an additional item will be stonecutting (saw) recipes
+	//		machine('copper','minecraft:dispenser', 2, 'minecraft:bow')          // Recipes with one are smithing table recipes
+	//
+	//      event.shapeless("create:creative_crate", "minecraft:redstone_ore")]) // If you have any other recipes, put them following the machine recipes
+	//}                                     
 
-if (Platform.isLoaded('createbigcannons')) {
+	if (Platform.isLoaded('createbigcannons')) {
 		machine('andesite','createbigcannons:yaw_controller', 1)
 		machine('andesite','createbigcannons:cannon_builder', 1, 'create:mechanical_bearing')
 		machine('andesite','createbigcannons:cannon_loader', 1, 'create:mechanical_piston')
 		machine('andesite','createbigcannons:cannon_drill', 1, 'create:fluid_tank')
 	}                         
 	
+	if (Platform.isLoaded('miners_delight')) {
+		event.remove({ id: 'miners_delight:cutting/bat_wing' })
+	}
+
+	if(Platform.isLoaded('create_edible_belts')) {
+		event.remove({ id: 'create_edible_belts:embrecipe' })
+	}
 })

--- a/overrides/kubejs/server_scripts/recipes.js
+++ b/overrides/kubejs/server_scripts/recipes.js
@@ -2009,7 +2009,7 @@ function invarMachine(event) {
 			"ingredients": [{ "item": TC(type + "_slime_fern") }],
 			"tool": { "tag": "forge:tools/knives" },
 			"result": [Item.of(KJ(type + "_slimy_fern_leaf"), 2).toResultJson()]
-		}).id(`kjs:cutting/${type}_slime_fern_leaf`).keepHeldItem = true;
+		}).id(`kjs:cutting/${type}_slime_fern_leaf`)
 		event.forEachRecipe({ id:`farmersdelight:kjs_${type}_slime_fern_leaf_using_deployer` }, r => { r.keepHeldItem = true })
 		event.custom({
 			"type": "occultism:spirit_fire",

--- a/overrides/kubejs/server_scripts/recipes.js
+++ b/overrides/kubejs/server_scripts/recipes.js
@@ -2010,13 +2010,12 @@ function invarMachine(event) {
 			"tool": { "tag": "forge:tools/knives" },
 			"result": [Item.of(KJ(type + "_slimy_fern_leaf"), 2).toResultJson()]
 		}).id(`kjs:cutting/${type}_slime_fern_leaf`)
-		event.forEachRecipe({ id:`farmersdelight:kjs_${type}_slime_fern_leaf_using_deployer` }, r => { r.keepHeldItem = true })
+		event.custom(ifiniDeploying(KJ(type + "_slimy_fern_leaf", 2), TC(type + "_slime_fern"), "#forge:tools/knives")).id(`kjs:deploying/${type}_slime_fern_leaf`)
 		event.custom({
 			"type": "occultism:spirit_fire",
 			"ingredient": { "item": KJ(type + "_slimy_fern_leaf") },
 			"result": { "item": TC(type + "_slime_fern") }
 		})
-		event.custom(ifiniDeploying(KJ(type + "_slimy_fern_leaf", 2), TC(type + "_slime_fern"), "#forge:tools/knives"))
 		event.recipes.createMilling([KJ(type + "_slime_fern_paste")], KJ(type + "_slimy_fern_leaf"))
 		event.campfireCooking(output, KJ(type + "_slime_fern_paste")).cookingTime(300)
 	}

--- a/overrides/kubejs/server_scripts/recipes.js
+++ b/overrides/kubejs/server_scripts/recipes.js
@@ -801,11 +801,6 @@ function tweaks(event) {
 	cast("plate", TC("molten_bronze"), 90, "alloyed:bronze_sheet", 50)
 	cast_block(TC("molten_bronze"), "alloyed:bronze_block")
 
-	remove_cast("smeltery/casting/metal/silver/plate")
-	remove_cast("smeltery/casting/metal/electrum/plate")
-	remove_cast("smeltery/casting/metal/silver/gear")
-	remove_cast("smeltery/casting/metal/electrum/gear")
-
 	event.custom({
 		"type": "tconstruct:melting",
 		"ingredient": {
@@ -2020,7 +2015,6 @@ function invarMachine(event) {
 			"ingredient": { "item": KJ(type + "_slimy_fern_leaf") },
 			"result": { "item": TC(type + "_slime_fern") }
 		})
-		event.custom(ifiniDeploying(KJ(type + "_slimy_fern_leaf", 2), TC(type + "_slime_fern"), "#forge:tools/knives"))
 		event.recipes.createMilling([KJ(type + "_slime_fern_paste")], KJ(type + "_slimy_fern_leaf"))
 		event.campfireCooking(output, KJ(type + "_slime_fern_paste")).cookingTime(300)
 	}

--- a/overrides/kubejs/server_scripts/recipes.js
+++ b/overrides/kubejs/server_scripts/recipes.js
@@ -2009,12 +2009,14 @@ function invarMachine(event) {
 			"ingredients": [{ "item": TC(type + "_slime_fern") }],
 			"tool": { "tag": "forge:tools/knives" },
 			"result": [Item.of(KJ(type + "_slimy_fern_leaf"), 2).toResultJson()]
-		})
+		}).id(`kjs:cutting/${type}_slime_fern_leaf`).keepHeldItem = true;
+		event.forEachRecipe({ id:`farmersdelight:kjs_${type}_slime_fern_leaf_using_deployer` }, r => { r.keepHeldItem = true })
 		event.custom({
 			"type": "occultism:spirit_fire",
 			"ingredient": { "item": KJ(type + "_slimy_fern_leaf") },
 			"result": { "item": TC(type + "_slime_fern") }
 		})
+		event.custom(ifiniDeploying(KJ(type + "_slimy_fern_leaf", 2), TC(type + "_slime_fern"), "#forge:tools/knives"))
 		event.recipes.createMilling([KJ(type + "_slime_fern_paste")], KJ(type + "_slimy_fern_leaf"))
 		event.campfireCooking(output, KJ(type + "_slime_fern_paste")).cookingTime(300)
 	}


### PR DESCRIPTION
**Main features**
Updates create to patch f
Adds create central kitchen to the pack to make farmer's delight recipes automatable.
Adds compatability scripts for edible belts and miner's delight.

**misc changes**
edit the mantle server config to auto correct smeltery outputs.

**Add these to the compatability spreadsheet**
spice of life carrot edition - *scripted compatability but requires default configs to be copied into the server folder on old worlds.
create edible belts - Scripted compatability
miner's delight plus -* Scipted / unscripted  compatability - removes phantom membrane recipe but changes nothing else.
farmer's respite - non scripted compatability
nether delight - non scripted compatability
end's delight - non scripted compatability
large meals - non scripted compatability