### PR TITLE
Add buddycards expansions and group/hide cards in jei

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -780,7 +780,12 @@
 				"fileID":4838717,
 				"projectID":820977,
 				"required":true
-		 }
+			},
+			{
+				"fileID":4953122,
+				"projectID":568127,
+				"required":true
+			}
 			
    ],
    "manifestType":"minecraftModpack",

--- a/modlist.html
+++ b/modlist.html
@@ -6,6 +6,7 @@
 <li><a href="https://www.curseforge.com/projects/220318">Biomes O' Plenty (by Forstride, Adubbz)</a></li>
 <li><a href="https://www.curseforge.com/projects/468893">Block Swap (by Corgi Taco)</a></li>
 <li><a href="https://www.curseforge.com/projects/425991">Buddycards (by Wildcard)</a></li>
+<li><a href="https://www.curseforge.com/projects/568127">Buddycards Expansions (by Wildcard)</a></li>
 <li><a href="https://www.curseforge.com/projects/258426">CB Multipart (by ChickenBones, covers1624)</a></li>
 <li><a href="https://www.curseforge.com/projects/267602">ConnectedTexturesMod (by tterrag, Drullkus, minecreatr)</a></li>
 <li><a href="https://www.curseforge.com/projects/231095">Chisels &amp; Bits - For Forge (by OrionOnline, LDTTeam, AlgorithmX2 )</a></li>

--- a/overrides/kubejs/client_scripts/JEI.js
+++ b/overrides/kubejs/client_scripts/JEI.js
@@ -64,13 +64,30 @@ onEvent('rei.group', event => {
 		/buddycards:buddycard_end/
 	])
 
+	event.groupItems('kubejs:rei_groups/buddycards_create_set', 'Buddy Cards Create Set', [
+		/buddycardsexp:buddycard_create/
+	])
+
+	event.groupItems('kubejs:rei_groups/buddycards_aquaculture_set', 'Buddy Cards Aquaculture Set', [
+		/buddycardsexp:buddycard_aquaculture/
+	])
+
+	event.groupItems("kubejs:rei_groups/buddycards_farmers_set", "Buddy Cards Farmer's Set", [
+		/buddycardsexp:buddycard_farmers/
+	])
+
+	event.groupItems('kubejs:rei_groups/buddycards_malum_set', 'Buddy Cards Malum Set', [
+		/buddycardsexp:buddycard_malum/
+	])
+
 	event.groupItems('kubejs:rei_groups/buddycards_holiday', 'Buddy Cards Holiday', [
 		"buddycards:buddycard_holiday1",
 		"buddycards:buddycard_holiday2",
 		"buddycards:buddycard_holiday3",
 		"buddycards:buddycard_holiday4",
 		"buddycards:buddycard_holiday5",
-		"buddycards:buddycard_holiday6"
+		"buddycards:buddycard_holiday6",
+		/buddycards:buddycard_holiday/
 	])
 
 })

--- a/overrides/kubejs/client_scripts/bulkhide.js
+++ b/overrides/kubejs/client_scripts/bulkhide.js
@@ -345,6 +345,10 @@ onEvent('rei.hide.items', event => {
 	event.hide('kubejs:silver_coin')   
 	event.hide('kubejs:gold_coin')
 	event.hide('thermal:servo_attachment')
+
+	if (!Platform.isLoaded("malum")) {
+		event.hide("#buddycardsexp:buddycards_malum")
+	}
 })
 
 onEvent('rei.hide.fluids', event => {


### PR DESCRIPTION
**Describe the PR**
Adds buddycards expansions and groups the cards / hides malum cards when malum is not installed.
Also fixes the holiday set grouping during christmas.

I recreated this branch because the original branch was messed up in a merge.
I gave up on trying to update the manifest version since I have no clue when this will be merged.