### PR TITLE
Create Enchantment Industry Compatability and Crafts and Additions tweaks

### DIFF
--- a/overrides/config/createaddition-common.toml
+++ b/overrides/config/createaddition-common.toml
@@ -1,0 +1,143 @@
+
+#General Settings
+[general]
+	#Forge Energy conversion rate (in FE/t at 256 RPM, value is the FE/t generated and consumed is at 256rpm).
+	#Range: > 0
+	fe_at_max_rpm = 480
+	#Max stress for the Alternator and Electric Motor (in SU at 256 RPM).
+	#Range: > 0
+	max_stress = 16384
+
+#Electric Motor
+[electric_motor]
+	#Electric Motor min/max RPM.
+	#Range: > 1
+	motor_rpm_range = 256
+	#Electric Motor minimum required energy consumption in FE/t.
+	#Range: > 0
+	motor_min_consumption = 8
+	#Electric Motor max input in FE (Energy transfer not consumption).
+	#Range: > 0
+	motor_max_input = 4000
+	#Electric Motor internal capacity in FE.
+	#Range: > 0
+	motor_capacity = 16000
+
+#Alternator
+[alternator]
+	#Alternator max input in FE (Energy transfer, not generation).
+	#Range: > 0
+	generator_max_output = 4000
+	#Alternator internal capacity in FE.
+	#Range: > 0
+	generator_capacity = 16000
+	#Alternator efficiency relative to base conversion rate.
+	#Range: 0.01 ~ 1.0
+	generator_efficiency = 0.75
+
+#Rolling Mill
+[rolling_mill]
+	#Rolling Mill duration in ticks.
+	#Range: > 0
+	rolling_mill_processing_duration = 100
+	#Rolling Mill base stress impact.
+	#Range: 0 ~ 1024
+	rolling_mill_stress = 16
+
+#Wires
+[wires]
+	#Small Connector max input in FE/t (Energy transfer).
+	#Range: > 0
+	small_connector_max_input = 1024
+	#Small Connector max output in FE/t (Energy transfer).
+	#Range: > 0
+	small_connector_max_output = 1024
+	#Small Connector max wire length in blocks.
+	#Range: 0 ~ 256
+	small_connector_wire_length = 16
+	#Large Connector max input in FE/t (Energy transfer).
+	#Range: > 0
+	large_connector_max_input = 4096
+	#Large Connector max output in FE/t (Energy transfer).
+	#Range: > 0
+	large_connector_max_output = 4096
+	#Large Connector max wire length in blocks.
+	#Range: 0 ~ 256
+	large_connector_wire_length = 32
+	#Ignore checking if block face can support connector.
+	connector_ignore_face_check = true
+	#Allows blocks attached to a connector to freely pass energy to and from the connector network.
+	connector_allow_passive_io = true
+
+#Accumulator
+[accumulator]
+	#Accumulator max input in FE/t (Energy transfer).
+	#Range: > 0
+	accumulator_max_input = 16000
+	#Accumulator max output in FE/t (Energy transfer).
+	#Range: > 0
+	accumulator_max_output = 16000
+	#Accumulator internal capacity per block in FE.
+	#Range: > 0
+	accumulator_capacity = 4000000
+	#Accumulator max multiblock height.
+	#Range: 1 ~ 8
+	accumulator_max_height = 5
+	#Accumulator max multiblock width.
+	#Range: 1 ~ 8
+	accumulator_max_width = 3
+
+#Portable Energy Interface
+[portable_energy_interface]
+	#PEI max input in FE/t (Energy transfer).
+	#Range: > 0
+	pei_max_input = 16000
+	#PEI max output in FE/t (Energy transfer).
+	#Range: > 0
+	pei_max_output = 16000
+
+#Tesla Coil
+[tesla_coil]
+	#Tesla Coil max input in FE/t (Energy transfer).
+	#Range: > 0
+	tesla_coil_max_input = 10000
+	#Tesla Coil charge rate in FE/t.
+	#Range: > 0
+	tesla_coil_charge_rate = 5000
+	#Tesla Coil charge rate in FE/t for recipes.
+	#Range: > 0
+	tesla_coil_recipe_charge_rate = 2000
+	#Tesla Coil internal capacity in FE.
+	#Range: > 0
+	tesla_coil_capacity = 40000
+	#Energy consumed when Tesla Coil is fired (in FE).
+	#Range: > 0
+	tesla_coil_hurt_energy_required = 1000
+	#Hurt range (in blocks/meters).
+	#Range: > 0
+	tesla_coil_hurt_range = 3
+	#Damaged dealt to mobs when Tesla Coil is fired (in half hearts).
+	#Range: > 0
+	tesla_coil_hurt_mob = 3
+	#The duration of the Shocked effect for mobs (in ticks).
+	#Range: > 0
+	tesla_coil_effect_time_mob = 20
+	#Damaged dealt to players when Tesla Coil is fired (in half hearts).
+	#Range: > 0
+	tesla_coil_hurt_player = 2
+	#The duration of the Shocked effect for players (in ticks).
+	#Range: > 0
+	tesla_coil_effect_time_player = 20
+	#Tesla Coil fire interval (in ticks).
+	#Range: > 0
+	tesla_coil_fire_cooldown = 20
+
+#Misc
+[misc]
+	#Diamond Grit Sandpaper durability (number of uses).
+	#Range: > 3
+	diamond_grit_sandpaper_uses = 1024
+	#Barbed Wire Damage.
+	#Range: 0.0 ~ 3.4028234663852886E38
+	barbed_wire_damage = 2.0
+

--- a/overrides/kubejs/client_scripts/client_compatibility.js
+++ b/overrides/kubejs/client_scripts/client_compatibility.js
@@ -8,5 +8,6 @@ onEvent('rei.hide.items', event => {
 		event.hide("createaddition:zinc_sheet")
 		//Unfortunately we have stick to thermal diamond dust due to the strainer recipe
 		event.hide("createaddition:diamond_grit")
+		event.hide("createaddition:accumulator")
 	}
 })

--- a/overrides/kubejs/server_scripts/loot.js
+++ b/overrides/kubejs/server_scripts/loot.js
@@ -54,7 +54,8 @@ let metal_ores_drop_dust = (id, dust_id) => ({
                                 0.25,
                                 0.375,
                                 0.5,
-                                0.625
+                                0.625,
+                                0.75
                             ]
                         }
                     ],

--- a/overrides/kubejs/server_scripts/recipes.js
+++ b/overrides/kubejs/server_scripts/recipes.js
@@ -444,7 +444,7 @@ function tweaks(event) {
 	event.shapeless(TE("item_filter_augment"), [CR("filter"), TE("lapis_gear")])
 
 	event.remove({ id: 'create_central_kitchen:crafting/cooking_guide' })
-	event.shapeless('create_central_kitchen:cooking_guide', [CR("schedule"), FD("canvas")])
+	event.shapeless('create_central_kitchen:cooking_guide', [F("#plates/obsidian"), FD("canvas")])
 	
 	event.stonecutting(AE2("silicon_press"), KJ("circuit_scrap"))
 	event.stonecutting(AE2("engineering_processor_press"), KJ("circuit_scrap"))

--- a/overrides/kubejs/server_scripts/server_compatibility.js
+++ b/overrides/kubejs/server_scripts/server_compatibility.js
@@ -4,7 +4,6 @@
 // If you have a create addon that you think could fit in the general theme/tone/whathaveyou of CABIN, make a PR with it.
 
 onEvent('recipes', event => {
-
 	let machine = (machinename, id, amount, other_ingredient) => {
 		event.remove({ output: id })
 		var machine_item = 'kubejs:'+ machinename + '_machine';
@@ -99,7 +98,16 @@ onEvent('recipes', event => {
 				event.recipes.createFilling('kubejs:incomplete_large_connector', ['kubejs:incomplete_large_connector', Fluid.of('tconstruct:molten_gold', 10)])
 			]
 		).transitionalItem('kubejs:incomplete_large_connector').loops(1)
-	}          
+	}
+
+	if (Platform.isLoaded('create_enchantment_industry')) {
+		event.remove( {id: 'create_enchantment_industry:crafting/disenchanter'})
+		event.remove( {id: 'create_enchantment_industry:crafting/printer'})
+
+		machine('copper', 'create_enchantment_industry:disenchanter', 1, '#create:sandpaper')
+		machine('copper', 'create_enchantment_industry:printer', 1, '#forge:storage_blocks/lapis')
+
+	}
 	
 	if (Platform.isLoaded('miners_delight')) {
 		event.remove({ id: 'miners_delight:cutting/bat_wing' })

--- a/overrides/kubejs/server_scripts/server_compatibility.js
+++ b/overrides/kubejs/server_scripts/server_compatibility.js
@@ -71,14 +71,13 @@ onEvent('recipes', event => {
 		event.recipes.createMechanicalCrafting('createaddition:redstone_relay', 'AB', { A: 'projectred_core:platformed_plate', B: 'createaddition:connector' })
 
 		// Remove heated basin ingot recipes
-		event.remove({ output: 'tconstruct:slimesteel_ingot', type: 'create:mixing'})
-		event.remove({ output: 'tconstruct:amethyst_bronze_ingot', type: 'create:mixing'})
-		event.remove({ output: 'tconstruct:rose_gold_ingot', type: 'create:mixing'})
-		event.remove({ output: 'tconstruct:pig_iron_ingot', type: 'create:mixing'})
-		event.remove({ output: 'tconstruct:queens_slime_ingot', type: 'create:mixing'})
-		event.remove({ output: 'tconstruct:manyullyn_ingot', type: 'create:mixing'})
-		event.remove({ output: 'tconstruct:hepatizon_ingot', type: 'create:mixing'})
+		event.remove({ id: "createaddition:mixing/electrum"} )
+		event.remove({ id: /createaddition:compat\/tconstruct/} )
 
+		// Connectors
+		event.remove( {id:"createaddition:crafting/small_connector_copper"})
+		event.remove( {id:"createaddition:crafting/large_connector_gold"})
+		event.remove( {id:"createaddition:crafting/large_connector_electrum"})
 		event.recipes.createSequencedAssembly(
 			[Item.of('createaddition:connector', 4)], 
 			'create:andesite_alloy', 
@@ -91,19 +90,18 @@ onEvent('recipes', event => {
 		
 		event.recipes.createSequencedAssembly(
 			[Item.of('createaddition:large_connector', 1)], 
-			'createaddition:connector', 
+			'create:andesite_alloy', 
 			[
-				event.recipes.createDeploying('kubejs:incomplete_large_connector', ['kubejs:incomplete_large_connector', '#forge:plates/iron']),
-				event.recipes.createPressing('kubejs:incomplete_large_connector', 'kubejs:incomplete_large_connector'),
-				event.recipes.createFilling('kubejs:incomplete_large_connector', ['kubejs:incomplete_large_connector', Fluid.of('tconstruct:molten_gold', 10)])
+				event.recipes.createDeploying('kubejs:incomplete_connector', ['kubejs:incomplete_connector', '#forge:rods/electrum']),
+				event.recipes.createDeploying('kubejs:incomplete_connector', ['kubejs:incomplete_connector', '#forge:plates/iron']),
+				event.recipes.createPressing('kubejs:incomplete_connector', 'kubejs:incomplete_connector'),
+				event.recipes.createDeploying('kubejs:incomplete_connector', ['kubejs:incomplete_connector', '#forge:plates/iron']),
+				event.recipes.createPressing('kubejs:incomplete_connector', 'kubejs:incomplete_connector')
 			]
 		).transitionalItem('kubejs:incomplete_large_connector').loops(1)
 	}
 
 	if (Platform.isLoaded('create_enchantment_industry')) {
-		event.remove( {id: 'create_enchantment_industry:crafting/disenchanter'})
-		event.remove( {id: 'create_enchantment_industry:crafting/printer'})
-
 		machine('copper', 'create_enchantment_industry:disenchanter', 1, '#create:sandpaper')
 		machine('copper', 'create_enchantment_industry:printer', 1, '#forge:storage_blocks/lapis')
 


### PR DESCRIPTION
**Describe the PR**
-create enchantment industry compat
-add fortune 6 to the metal ore drop table
-change cooking guide to use obsidian sheet instead of schedule
-tweak create crafts and additions recipes
-buff the alternator from C&A to make it competitive with the thermal energy cell