### PR TITLE
Add create:wrench_pickup tag to more blocks

### DIFF
--- a/overrides/kubejs/server_scripts/tags.js
+++ b/overrides/kubejs/server_scripts/tags.js
@@ -1,9 +1,9 @@
 onEvent('item.tags', event => {
-    event.add('forge:computation_matrix', 'kubejs:computation_matrix')
-    event.add('forge:enderium_machine', 'kubejs:enderium_machine')
-    event.add('forge:controller', 'ae2:controller')
-    event.add('forge:iron_block', 'minecraft:iron_block')
-	})
+	event.add('forge:computation_matrix', 'kubejs:computation_matrix')
+	event.add('forge:enderium_machine', 'kubejs:enderium_machine')
+	event.add('forge:controller', 'ae2:controller')
+	event.add('forge:iron_block', 'minecraft:iron_block')
+})
 
 onEvent('block.tags', event => {
 	event.add('minecraft:beacon_base_blocks', 'alloyed:steel_block')

--- a/overrides/kubejs/server_scripts/tags.js
+++ b/overrides/kubejs/server_scripts/tags.js
@@ -32,8 +32,8 @@ onEvent('block.tags', event => {
 	event.add("create:wrench_pickup", 'supplementaries:spring_launcher')
 	//event.add("create:wrench_pickup", 'supplementaries:speaker_block') //note block and jukebox are not wrenchable
 	event.add("create:wrench_pickup", 'supplementaries:turn_table')
-	event.add("create:wrench_pickup", 'supplementaries:pulley_block')
-	event.add("create:wrench_pickup", 'supplementaries:hourglass')
+	//event.add("create:wrench_pickup", 'supplementaries:pulley_block')
+	//event.add("create:wrench_pickup", 'supplementaries:hourglass')
 	event.add("create:wrench_pickup", 'supplementaries:bellows')
 	event.add("create:wrench_pickup", 'supplementaries:clock_block')
 	event.add("create:wrench_pickup", 'supplementaries:crystal_display')

--- a/overrides/kubejs/server_scripts/tags.js
+++ b/overrides/kubejs/server_scripts/tags.js
@@ -3,7 +3,7 @@ onEvent('item.tags', event => {
     event.add('forge:enderium_machine', 'kubejs:enderium_machine')
     event.add('forge:controller', 'ae2:controller')
     event.add('forge:iron_block', 'minecraft:iron_block')
-})
+	})
 
 onEvent('block.tags', event => {
 	event.add('minecraft:beacon_base_blocks', 'alloyed:steel_block')
@@ -22,4 +22,28 @@ onEvent('block.tags', event => {
 	event.add("create:wrench_pickup", "thermal:energy_duct")
 	event.add("create:wrench_pickup", "thermal:fluid_duct")
 	event.add("create:wrench_pickup", "thermal:fluid_duct_windowed")
+
+	event.add("create:wrench_pickup", /storagedrawers:/)
+
+	event.add("create:wrench_pickup", 'quark:ender_watcher')
+
+	event.add("create:wrench_pickup", 'supplementaries:cog_block')
+	event.add("create:wrench_pickup", 'supplementaries:relayer')
+	event.add("create:wrench_pickup", 'supplementaries:spring_launcher')
+	//event.add("create:wrench_pickup", 'supplementaries:speaker_block') //note block and jukebox are not wrenchable
+	event.add("create:wrench_pickup", 'supplementaries:turn_table')
+	event.add("create:wrench_pickup", 'supplementaries:pulley_block')
+	event.add("create:wrench_pickup", 'supplementaries:hourglass')
+	event.add("create:wrench_pickup", 'supplementaries:bellows')
+	event.add("create:wrench_pickup", 'supplementaries:clock_block')
+	event.add("create:wrench_pickup", 'supplementaries:crystal_display')
+	event.add("create:wrench_pickup", 'supplementaries:sconce_lever')
+	event.add("create:wrench_pickup", 'supplementaries:crank')
+	event.add("create:wrench_pickup", 'supplementaries:wind_vane')
+	event.add("create:wrench_pickup", 'supplementaries:faucet')
+
+	//I really don't know why these blocks are missing the pressure plate tag
+	//All the other pressure plates from quark and forbidden have the tag.
+	event.add("minecraft:pressure_plates", 'quark:obsidian_pressure_plate')
+	event.add("minecraft:pressure_plates", 'forbidden_arcanus:polished_darkstone_pressure_plate')
 })


### PR DESCRIPTION
**Describe the PR**
Makes all storage drawers wrenchable
Makes the ender watcher from quark wrenchable
Makes most of supplementaries' redstone related blocks wrenchable

Adds the pressure plate tag to the 2 pressure plates that are missing the tag