### PR TITLE
increase screwdriver durability to 512

### DIFF
--- a/overrides/kubejs/startup_scripts/generate.js
+++ b/overrides/kubejs/startup_scripts/generate.js
@@ -350,5 +350,9 @@ onEvent('item.modification', event => {
 			item.maxStackSize = 1
 		})
 	});
+
+	event.modify('projectred_core:screwdriver', item => {
+		item.maxDamage = 256
+	})
 })
 

--- a/overrides/kubejs/startup_scripts/generate.js
+++ b/overrides/kubejs/startup_scripts/generate.js
@@ -352,7 +352,7 @@ onEvent('item.modification', event => {
 	});
 
 	event.modify('projectred_core:screwdriver', item => {
-		item.maxDamage = 256
+		item.maxDamage = 512
 	})
 })
 


### PR DESCRIPTION
This pull request increases the screwdriver's durability from its pitiful 128 durability to a less pitiful 256 durability

That is all



This gives the screwdriver a durability amount that more closely matches other iron tools like iron pickaxes and iron saws. You could probably argue for it being raised further to 512 to match with the chromatic resonator and flash drive.