### PR TITLE
fix smeltery bug in dust_process

### DIFF
--- a/overrides/kubejs/server_scripts/recipes.js
+++ b/overrides/kubejs/server_scripts/recipes.js
@@ -1542,7 +1542,7 @@ function oreProcessing(event) {
 		event.custom({
 			"type": "tconstruct:melting",
 			"ingredient": {
-				"tag": dusttag
+				"tag": dusttag.slice(1)
 			},
 			"result": {
 				"fluid": fluid,

--- a/overrides/kubejs/server_scripts/tags.js
+++ b/overrides/kubejs/server_scripts/tags.js
@@ -3,6 +3,9 @@ onEvent('item.tags', event => {
 	event.add('forge:enderium_machine', 'kubejs:enderium_machine')
 	event.add('forge:controller', 'ae2:controller')
 	event.add('forge:iron_block', 'minecraft:iron_block')
+
+	event.add('forge:dusts/obsidian', 'create:powdered_obsidian')
+	event.add('forge:dusts', 'create:powdered_obsidian')
 })
 
 onEvent('block.tags', event => {


### PR DESCRIPTION
**Describe the PR**
I made a massive mistake in an earlier pr that caused smeltery dust recipes to break.
This fixes that.

The problem was the the dusttag would get a hashtag in its name causing the recipe to not work.

**Edit**
Fix tags on powdered obsidian so that the obsidian reagent is craftable (why didn't it have the tag already?)