### PR TITLE
Create Power Loader Compat

### DIFF
--- a/overrides/kubejs/server_scripts/server_compatability/create_power_loader.js
+++ b/overrides/kubejs/server_scripts/server_compatability/create_power_loader.js
@@ -1,0 +1,6 @@
+if (Platform.isLoaded('create_power_loader')) { 
+	onEvent('recipes', event => {
+		brassMachine(event,Item.of('create_power_loader:empty_brass_chunk_loader', 1), 'minecraft:nether_star')
+		andesiteMachine(event,Item.of('create_power_loader:empty_andesite_chunk_loader', 1), 'minecraft:wither_skeleton_skull')
+	})
+}


### PR DESCRIPTION
**Description**
Adds compatibility for the [Create Power Loader](https://www.curseforge.com/minecraft/mc-mods/create-power-loader) mod. While there is a create chunk loading mod currently in the pack, this one feels far more immersive both functionally and aesthetically

Currently, the brass loader is made with a brass machine and a nether star, while the andesite loader is made with an andesite machine and wither skeleton skull (feel free to suggest changes)
