### PR TITLE
1.3.2 bug fixes

### DIFF
--- a/overrides/config/randomium-common.toml
+++ b/overrides/config/randomium-common.toml
@@ -38,10 +38,10 @@
 	base_drop_chance = 0.0
 	#Multiplier applied to each luck level the player has
 	#Range: 0.0 ~ 20.0
-	luck_multiplier = 1.0
+	luck_multiplier = 0.0
 	#Multiplier applied to each fortune level the player has
 	#Range: 0.0 ~ 20.0
-	fortune_multiplier = 0.2
+	fortune_multiplier = 0.0
 	#Allow the block to be silk touched
 	allow_silk_touch = true
 

--- a/overrides/kubejs/server_scripts/server_compatability/create_power_loader.js
+++ b/overrides/kubejs/server_scripts/server_compatability/create_power_loader.js
@@ -1,6 +1,6 @@
 if (Platform.isLoaded('create_power_loader')) { 
 	onEvent('recipes', event => {
+		andesiteMachine(event,Item.of('create_power_loader:empty_andesite_chunk_loader', 1), 'minecraft:ghast_tear')
 		brassMachine(event,Item.of('create_power_loader:empty_brass_chunk_loader', 1), 'minecraft:nether_star')
-		andesiteMachine(event,Item.of('create_power_loader:empty_andesite_chunk_loader', 1), 'minecraft:wither_skeleton_skull')
 	})
 }

--- a/overrides/kubejs/startup_scripts/blacklist.js
+++ b/overrides/kubejs/startup_scripts/blacklist.js
@@ -264,18 +264,6 @@ global.itemBlacklist = [
 
 	//Expanded Caves
 	'expcaves:plant_fiber', //useless inventory bloat
-	/* There next few items don't seem to generate for whatever reason.
-	   Let the CABIN discord know if you somehow find these in your world */
-	'expcaves:sweetshroom',
-	'expcaves:goldishroom',
-	'expcaves:shinyshroom',
-	'expcaves:lumishroom',
-	'expcaves:fluoshroom',
-	'expcaves:rockshroom',
-	'expcaves:cooked_sweetshroom',
-	'expcaves:sticky_stew',
-	'expcaves:fluorescent_stew',
-	'expcaves:hard_stew',
 	/* unobtainable, probably meant to come from structures that aren't in this version */
 	'expcaves:butcher_knife',
 	'expcaves:chef_knife',


### PR DESCRIPTION
Fixes stabilized randomium dropping from randomium when mined with fortune or luck
Unblacklists expanded caves mushrooms since they can generate on surface podzol
Tweaks andesite chunkloader recipe from create powerloaders to use a ghast tear instead of a wither skeleton skull