### PR TITLE
Chiller changes

### DIFF
--- a/overrides/kubejs/client_scripts/bulkhide.js
+++ b/overrides/kubejs/client_scripts/bulkhide.js
@@ -8,9 +8,6 @@ onEvent('rei.hide.items', event => {
 })
 
 onEvent('rei.hide.fluids', event => {
-	global.fluidBlacklist.forEach(fluid=>{
-		event.hide(fluid);
-	})
 	global.jeiFluidBlacklist.forEach(fluid=>{
 		event.hide(fluid);
 	})

--- a/overrides/kubejs/server_scripts/_helper.js
+++ b/overrides/kubejs/server_scripts/_helper.js
@@ -123,3 +123,29 @@ const addChiselingRecipe = (event, id, items, overwrite) => {
 	})
 	event.addJson(id, json)
 }
+
+/**
+ * Gets the prefered item from a tag. Useful for porting Mantle recipes that use tags as outputs.
+ * @param {string} tag Don't include a hashtag in the tag name
+ */
+// const ItemOutput = java('slimeknights.mantle.recipe.helper.ItemOutput');
+// const TagKey = java('net.minecraft.tags.TagKey');
+// const Registry = java('net.minecraft.core.Registry');
+const getPreferredTag = (tag) => {
+	/* Tried using mantle for this and it didn't work on first launch unfortunately */
+	//return Item.of(ItemOutput.fromTag(TagKey.create(Registry.ITEM_REGISTRY, tag), 1).get()).getId();
+	/* Create a copy of the mantle preferred mods list */
+	const preferredMods = ["minecraft", "create", "alloyed", "createdeco", "createaddition", "create_dd", "thermal", "tconstruct", "tmechworks"];
+	const tagItems = Ingredient.of('#' + tag).itemIds;
+	for (let i=0;i<preferredMods.length;++i) { let modId = preferredMods[i];
+		for (let j=0;j<tagItems.length;++j) { let itemId = tagItems[j];
+			if (itemId.split(':')[0]===modId) {
+				return itemId;
+			}
+		}
+	}
+	if (tagItems.length>0) {
+		return tagItems[0];
+	}
+	return 'minecraft:air';
+}

--- a/overrides/kubejs/server_scripts/key_mods/tconstruct.js
+++ b/overrides/kubejs/server_scripts/key_mods/tconstruct.js
@@ -46,4 +46,5 @@ onEvent('item.tags', event => {
 
 onEvent('block.tags', event => {
 	event.add('minecraft:mineable/shovel','tconstruct:mud_bricks_slab')
+	event.add('minecraft:mineable/shovel','tconstruct:mud_bricks_stairs')
 })

--- a/overrides/kubejs/server_scripts/recipes/chapters.js
+++ b/overrides/kubejs/server_scripts/recipes/chapters.js
@@ -211,7 +211,7 @@ onEvent('recipes', event => {
 	copperMachine(event, Item.of('kubejs:attachment_base', 1), CR('mechanical_pump'))
 	//smeltery controller recipe
 	event.remove({ id: TC("smeltery/casting/seared/smeltery_controller") })
-	event.remove({ id: TC("smeltery/melting/copper/smeltery_controller") })
+	event.remove({ id: TC("smeltery/melting/metal/copper/smeltery_controller") })
 	donutCraft(event, TC('smeltery_controller'), TC('#seared_blocks'), KJ('sealed_mechanism')).modifyResult((grid, result) => {
 		let item = grid.find(TC("#seared_blocks"))
 		return result.withNBT({texture: item.id})

--- a/overrides/kubejs/server_scripts/recipes/trading.js
+++ b/overrides/kubejs/server_scripts/recipes/trading.js
@@ -1,6 +1,11 @@
 
 onEvent('recipes', event => {
 	event.remove({ input: '#forge:coins' })
+	event.remove({ id:TC('smeltery/casting/metal/gold/coin_gold_cast') })
+	event.remove({ id:TC('smeltery/casting/metal/gold/coin_sand_cast') })
+	event.remove({ id:TC('smeltery/casting/metal/silver/coin_gold_cast') })
+	event.remove({ id:TC('smeltery/casting/metal/silver/coin_sand_cast') })
+
 	event.recipes.thermal.numismatic_fuel(TE('silver_coin')).energy(100000)
 	event.recipes.thermal.numismatic_fuel(TE('gold_coin')).energy(6400000)
 	//remove all press recipes

--- a/overrides/kubejs/server_scripts/tags.js
+++ b/overrides/kubejs/server_scripts/tags.js
@@ -87,7 +87,7 @@ onEvent('item.tags', event => {
 	event.get('thermal:crafting/dies').add('#kubejs:transaction_cards')
 	event.get('thermal:crafting/dies').add('kubejs:missingno')
 
-	event.get('thermal:crafting/casts').add(KJ("three_cast")).add(KJ("eight_cast")).add(KJ("plus_cast")).add(KJ("minus_cast")).add(KJ("multiply_cast")).add(KJ("divide_cast")).add(F("#circuit_press"))
+	event.get('thermal:crafting/casts').add(KJ("three_cast")).add(KJ("eight_cast")).add(KJ("plus_cast")).add(KJ("minus_cast")).add(KJ("multiply_cast")).add(KJ("divide_cast")).add(KJ("#circuit_press"))
 
 	event.get('create:upright_on_belt')
 		.add(AE2("red_paint_ball"))

--- a/overrides/kubejs/startup_scripts/blacklist.js
+++ b/overrides/kubejs/startup_scripts/blacklist.js
@@ -999,15 +999,113 @@ global.randomiumBlacklist = [
 	'modonomicon:modonomicon'
 ]
 
-//Global blacklist for fluids that will be hidden from jei
-global.fluidBlacklist = [
+global.jeiFluidBlacklist = [
+	//Most of this blacklist if filled with flowing fluid variants that sometimes show in rei when using tags
+	
+	'minecraft:flowing_water',
+	'minecraft:flowing_lava',
+
 	//Beyond Earth
 	'beyond_earth:molten_ostrum',
 	'beyond_earth:molten_calorite',
-	//Tconstruct
-	'tconstruct:molten_tin'
-]
 
-global.jeiFluidBlacklist = [
-	
+	'beyond_earth:flowing_fuel',
+	'beyond_earth:flowing_oil',
+	'beyond_earth:flowing_molten_desh',
+	'beyond_earth:flowing_molten_ostrum',
+	'beyond_earth:flowing_molten_calorite',
+
+	//biomes o plenty
+	'biomesoplenty:flowing_blood',
+
+	//decorative_blocks
+	'decorative_blocks:flowing_thatch',
+
+	//Tconstruct
+	'tconstruct:molten_tin',
+
+	'tconstruct:flowing_blood',
+	'tconstruct:flowing_venom',
+	'tconstruct:flowing_earth_slime',
+	'tconstruct:flowing_sky_slime',
+	'tconstruct:flowing_ender_slime',
+	'tconstruct:flowing_magma',
+	'tconstruct:flowing_honey',
+	'tconstruct:flowing_beetroot_soup',
+	'tconstruct:flowing_mushroom_stew',
+	'tconstruct:flowing_rabbit_stew',
+	'tconstruct:flowing_seared_stone',
+	'tconstruct:flowing_scorched_stone',
+	'tconstruct:flowing_molten_clay',
+	'tconstruct:flowing_molten_glass',
+	'tconstruct:flowing_liquid_soul',
+	'tconstruct:flowing_molten_obsidian',
+	'tconstruct:flowing_molten_ender',
+	'tconstruct:flowing_blazing_blood',
+	'tconstruct:flowing_molten_emerald',
+	'tconstruct:flowing_molten_quartz',
+	'tconstruct:flowing_molten_amethyst',
+	'tconstruct:flowing_molten_diamond',
+	'tconstruct:flowing_molten_debris',
+	'tconstruct:flowing_molten_iron',
+	'tconstruct:flowing_molten_gold',
+	'tconstruct:flowing_molten_copper',
+	'tconstruct:flowing_molten_cobalt',
+	'tconstruct:flowing_molten_slimesteel',
+	'tconstruct:flowing_molten_amethyst_bronze',
+	'tconstruct:flowing_molten_rose_gold',
+	'tconstruct:flowing_molten_pig_iron',
+	'tconstruct:flowing_molten_manyullyn',
+	'tconstruct:flowing_molten_hepatizon',
+	'tconstruct:flowing_molten_queens_slime',
+	'tconstruct:flowing_molten_netherite',
+	'tconstruct:flowing_molten_tin',
+	'tconstruct:flowing_molten_lead',
+	'tconstruct:flowing_molten_silver',
+	'tconstruct:flowing_molten_nickel',
+	'tconstruct:flowing_molten_zinc',
+	'tconstruct:flowing_molten_bronze',
+	'tconstruct:flowing_molten_brass',
+	'tconstruct:flowing_molten_electrum',
+	'tconstruct:flowing_molten_invar',
+	'tconstruct:flowing_molten_constantan',
+	'tconstruct:flowing_molten_steel',
+	'tconstruct:flowing_molten_enderium',
+	'tconstruct:flowing_molten_lumium',
+	'tconstruct:flowing_molten_signalum',
+
+	//other tinker's fluids that don't show up in the main pack
+	'tconstruct:flowing_molten_aluminum',
+	'tconstruct:flowing_molten_osmium',
+	'tconstruct:flowing_molten_pewter',
+	'tconstruct:flowing_molten_porcelain',
+	'tconstruct:flowing_molten_refined_glowstone',
+	'tconstruct:flowing_molten_refined_obsidian',
+	'tconstruct:flowing_molten_tungsten',
+	'tconstruct:flowing_molten_uranium',
+
+	//kubejs fluids
+	'kubejs:flowing_raw_logic',
+	'kubejs:flowing_number_0',
+	'kubejs:flowing_number_1',
+	'kubejs:flowing_number_2',
+	'kubejs:flowing_number_3',
+	'kubejs:flowing_number_4',
+	'kubejs:flowing_number_5',
+	'kubejs:flowing_number_6',
+	'kubejs:flowing_number_7',
+	'kubejs:flowing_number_8',
+	'kubejs:flowing_number_9',
+	'kubejs:flowing_matrix',
+	'kubejs:flowing_fine_sand',
+	'kubejs:flowing_crude_oil',
+	'kubejs:flowing_volatile_sky_solution',
+	'kubejs:flowing_chromatic_waste',
+
+	//Create fluids
+	'create:flowing_honey',
+	'create:flowing_chocolate',
+	//Central Kitchen
+	'create_central_kitchen:flowing_tomato_sauce',
+
 ]


### PR DESCRIPTION
Removes the fluidBlacklist constant since it is redundant
Fixes mud bricks stairs having no preferred tool
removes the ability to cast coins and melt smelteries
Fixes circuit presses being consumed in chiller recipes
Automatically ports all ingot and rod casting recipes to the chiller.