### PR TITLE
fix incorrect copper byproducts and simplify ore processing script

### DIFF
--- a/overrides/kubejs/server_scripts/_helper.js
+++ b/overrides/kubejs/server_scripts/_helper.js
@@ -134,7 +134,7 @@ const addChiselingRecipe = (event, id, items, overwrite) => {
  * @param {string} tag Don't include a hashtag in the tag name
  */
 // const ItemOutput = java('slimeknights.mantle.recipe.helper.ItemOutput');
-const getPreferredTag = (tag) => {
+const getPreferredItemFromTag = (tag) => {
 	/* Tried using mantle for this and it didn't work on first launch unfortunately */
 	//return Item.of(ItemOutput.fromTag(TagKey.create(Registry.ITEM_REGISTRY, tag), 1).get()).getId();
 	/* Create a copy of the mantle preferred mods list */

--- a/overrides/kubejs/server_scripts/key_mods/thermal.js
+++ b/overrides/kubejs/server_scripts/key_mods/thermal.js
@@ -115,7 +115,7 @@ onEvent('recipes', event => {
 		if (typeof recipeJSON.result === 'string') {
 			resultItem = {item:recipeJSON.result, count:1};
 		} else {
-			resultItem = {item:getPreferredTag(recipeJSON.result.tag), count:1}
+			resultItem = {item:getPreferredItemFromTag(recipeJSON.result.tag), count:1}
 			;
 		}
 


### PR DESCRIPTION
Fixes copper ore outputting copper again as a byproduct
Reworks ore processing script to have less parameters and be easier to understand
Also seems like it may have fixed a bug in the script that caused some recipes to not be removed when they should've been