### PR TITLE
port dust ingot and gem melting recipes to the magma crucible

### DIFF
--- a/overrides/kubejs/server_scripts/key_mods/thermal.js
+++ b/overrides/kubejs/server_scripts/key_mods/thermal.js
@@ -115,8 +115,7 @@ onEvent('recipes', event => {
 		if (typeof recipeJSON.result === 'string') {
 			resultItem = {item:recipeJSON.result, count:1};
 		} else {
-			resultItem = {item:getPreferredItemFromTag(recipeJSON.result.tag), count:1}
-			;
+			resultItem = {item:getPreferredItemFromTag(recipeJSON.result.tag), count:1};
 		}
 
 		//We don't want this recipe
@@ -135,4 +134,24 @@ onEvent('recipes', event => {
 	event.recipes.thermal.chiller(TC('sky_slime_ball'), [Fluid.of("tconstruct:sky_slime", 250), TE("chiller_ball_cast")]).energy(5000).id('kubejs:chiller/sky_slime_ball');
 	event.recipes.thermal.chiller(TC('ender_slime_ball'), [Fluid.of("tconstruct:ender_slime", 250), TE("chiller_ball_cast")]).energy(5000).id('kubejs:chiller/ender_slime_ball');
 	event.recipes.thermal.chiller(TC('blood_slime_ball'), [Fluid.of("tconstruct:blood", 250), TE("chiller_ball_cast")]).energy(5000).id('kubejs:chiller/blood_slime_ball');
+
+	//port melting recipes for dusts, ingots and gems
+	event.forEachRecipe([
+		{ type: 'tconstruct:melting', input: ['#forge:ingots', '#forge:gems'] },
+		{ type: 'tconstruct:melting', input: '#forge:dusts', not: {input: '#kubejs:ore_processing/metal/dusts' }}
+	], recipe => {
+		//recipe.json gives us some info that the recipe object cannot give us
+		let recipeJSON = JSON.parse(recipe.json)
+
+		let inputItem = recipeJSON.ingredient;
+		let resultFluid = recipeJSON.result;
+		
+		//Creating the ported recipe
+		event.custom({
+			type:"thermal:crucible",
+			ingredients:[inputItem],
+			result:[resultFluid],
+			energy:recipeJSON.time*50
+		}).id(`kubejs:crucible/${recipe.getId().replace(':', '/')}`)
+	})
 })

--- a/overrides/kubejs/server_scripts/recipes/chapters.js
+++ b/overrides/kubejs/server_scripts/recipes/chapters.js
@@ -385,6 +385,7 @@ onEvent('recipes', event => {
 	zincMachine(event, Item.of('thermal:upgrade_augment_2', 1), MC('redstone'))
 	// Foundry Controller Recipe
 	event.remove({ id: TC('smeltery/casting/scorched/foundry_controller') })
+	event.remove({ id: TC('smeltery/melting/obsidian/foundry_controller') })
 	donutCraft(event, TC('foundry_controller'), TC('#scorched_blocks'), KJ('infernal_mechanism')).modifyResult((grid, result) => {
 		let item = grid.find(TC("#scorched_blocks"))
 		return result.withNBT({texture: item.id})
@@ -632,8 +633,7 @@ onEvent('recipes', event => {
 	//Goodbye Inscriber
 	event.remove({ id: AE2('network/blocks/inscribers') })
 	event.remove({ type: AE2('inscriber') })
-	//magma crucible diamond melting
-	event.recipes.thermal.crucible(Fluid.of(TC("molten_diamond"), 100), MC("diamond")).energy(10000)
+	//all gem melting recipes are automatically ported to megma crucible recipe in thermal.js
 	//Printed Processors
 	event.custom({
 		"type": "tconstruct:casting_table",

--- a/overrides/kubejs/server_scripts/recipes/metallurgy.js
+++ b/overrides/kubejs/server_scripts/recipes/metallurgy.js
@@ -300,7 +300,7 @@ onEvent('recipes', event => {
 		//raw ore block compression and decompression
 		event.replaceInput({type: 'minecraft:crafting_shaped'}, rawOreTag, crushedOre)
 		event.replaceOutput({type: 'minecraft:crafting_shapeless'}, rawOreTag, crushedOre)
-		
+
 		event.remove({ input: rawOreTag })
 		event.remove({ input: oreTag, type: TE("smelter") })
 		event.remove({ input: oreTag, type: TE("pulverizer") })
@@ -338,7 +338,7 @@ onEvent('recipes', event => {
 		event.recipes.createMixing([Fluid.of(fluid, 180)], [Item.of(dustTag, 3), AE2('matter_ball')]).superheated().id('kubejs:ore_processing/mixing/dust/'+materialName)
 		
 		//ingots to fluid
-		event.recipes.thermal.crucible(Fluid.of(fluid, 90), ingot).energy(2000).id('kubejs:ore_processing/crucible/ingot/'+materialName)
+		//event.recipes.thermal.crucible(Fluid.of(fluid, 90), ingot).energy(2000).id('kubejs:ore_processing/crucible/ingot/'+materialName) //now automatically ported
 		
 		//melting crushed ores to fluid
 		event.custom({

--- a/overrides/kubejs/server_scripts/tags.js
+++ b/overrides/kubejs/server_scripts/tags.js
@@ -199,6 +199,14 @@ onEvent('item.tags', event => {
 		.add(MC('chorus_fruit'))
 		.add(MC('blaze_powder'))
 
+	event.get('kubejs:ore_processing/metal/dusts')
+		.add('#forge:dusts/copper')
+		.add('#forge:dusts/iron')
+		.add('#forge:dusts/gold')
+		.add('#forge:dusts/zinc')
+		.add('#forge:dusts/lead')
+		.add('#forge:dusts/nickel')
+
 	//This tag auto adds the beacon_payment_items tag which we don't want
 	event.remove(CR('create_ingots'), CR('andesite_alloy'))
 })

--- a/overrides/kubejs/startup_scripts/blacklist.js
+++ b/overrides/kubejs/startup_scripts/blacklist.js
@@ -649,6 +649,7 @@ global.randomiumBlacklist = [
 	'expcaves:treasure_amphora',
 	'expcaves:small_quartz_treasure_pot',
 	'expcaves:quartz_treasure_amphora',
+	'occultism:miner_debug_unspecialized',
 
 
 	//Tconstruct molten fluid buckets


### PR DESCRIPTION
-Ports dust recipes, ingot melting and gem melting recipes from the melter to the magma crucible
-Blacklists the debug ore miner from randomium ore
-Removes the melting recipe for the foundry controller