### PR TITLE
Compatibilty Script for Create: Balanced Flight

### DIFF
--- a/overrides/kubejs/server_scripts/recipes/chapters.js
+++ b/overrides/kubejs/server_scripts/recipes/chapters.js
@@ -338,7 +338,7 @@ onEvent('recipes', event => {
 	// Machine Crafting
 	brassMachine(event, Item.of('create:mechanical_crafter', 3), MC('crafting_table'))
 	brassMachine(event, Item.of('create:sequenced_gearshift', 2))
-	brassMachine(event, Item.of('create:steam_engine', 1))
+	brassMachine(event, Item.of('create:steam_engine', 1), MC('copper_block'))
 	brassMachine(event, Item.of('create:rotation_speed_controller', 1))
 	brassMachine(event, Item.of('create:mechanical_arm', 1))
 	brassMachine(event, Item.of('create:stockpile_switch', 2))

--- a/overrides/kubejs/server_scripts/server_compatability/balancedflight.js
+++ b/overrides/kubejs/server_scripts/server_compatability/balancedflight.js
@@ -1,0 +1,13 @@
+if(Platform.isLoaded("balancedflight")) {
+	onEvent('recipes', event => {
+	event.remove({ output: 'balancedflight:flight_anchor' })
+	event.recipes.createSequencedAssembly([
+	   'balancedflight:flight_anchor',
+	], 'minecraft:beacon', [
+		event.recipes.createDeploying(MC('beacon'), [MC('beacon'), KJ('inductive_mechanism')]),
+		event.recipes.createDeploying(MC('beacon'), [MC('beacon'), CR('railway_casing')]),
+		event.recipes.createDeploying(MC('beacon'), [MC('beacon'), CR('shaft')]),
+		event.recipes.createDeploying(MC('beacon'), [MC('beacon'), MC('elytra')]),
+	]).loops(1)
+  })
+}

--- a/overrides/kubejs/server_scripts/server_compatability/balancedflight.js
+++ b/overrides/kubejs/server_scripts/server_compatability/balancedflight.js
@@ -9,5 +9,10 @@ if(Platform.isLoaded("balancedflight")) {
 		event.recipes.createDeploying(MC('beacon'), [MC('beacon'), CR('shaft')]),
 		event.recipes.createDeploying(MC('beacon'), [MC('beacon'), MC('elytra')]),
 	]).loops(1)
+	event.replaceInput(
+		{ output: 'balancedflight:ascended_flight_ring' },
+		'minecraft:netherite_block',            
+		'kubejs:computation_matrix'
+	  )
   })
 }


### PR DESCRIPTION
**Describe the PR**
Changes the flight anchor & angel ring recipes to fit inside CABIN`s progression line.

Flight Anchor:
- Replaced Feather with Elytra
- Replaced Precision mechanism with Induction mechanism
- Miscellaneous tweaks to the rest of the recipe 

Angel Ring:
- Replaced Netherite blocks with Computation matrices

**Additional context**
- Flight anchor:
Replacing the feather makes this item be in balance with the magic feather, and replacing the p. mechanism makes it be tied to Chapter 4+ (In order to balance the anchor`s bigger AoE (At full speed) compared to the small area of the magic feather, and also considering that only a single elytra is required to make an anchor that makes _all players_ be able to flight.)
- Angel ring:
Replacing the netherite blocks makes this item a reward for completing almost every quest, rather than being a reward for simply grinding out half nether (Besides, it's pretty easy to get ridiculous amounts of netherite with a create strip-mining contraption.)

So, in conclusion, all these changes end up creating this new progression line:
- Magic Feather: Mid-game
- Anchor: Late-game
- Angel Ring: End-game

NEW:
Also changed the recipe of the Steam Engine, because brass cannot just become copper out of nowhere; This should be a serious tech science reddit gaming mumbo-jumbo modpack.
