### PR TITLE
Compatibility script for Create: Steam Powered

### DIFF
--- a/overrides/kubejs/server_scripts/recipes/chapters.js
+++ b/overrides/kubejs/server_scripts/recipes/chapters.js
@@ -338,7 +338,7 @@ onEvent('recipes', event => {
 	// Machine Crafting
 	brassMachine(event, Item.of('create:mechanical_crafter', 3), MC('crafting_table'))
 	brassMachine(event, Item.of('create:sequenced_gearshift', 2))
-	brassMachine(event, Item.of('create:steam_engine', 1))
+	brassMachine(event, Item.of('create:steam_engine', 1), MC('copper_block'))
 	brassMachine(event, Item.of('create:rotation_speed_controller', 1))
 	brassMachine(event, Item.of('create:mechanical_arm', 1))
 	brassMachine(event, Item.of('create:stockpile_switch', 2))

--- a/overrides/kubejs/server_scripts/server_compatability/balancedflight.js
+++ b/overrides/kubejs/server_scripts/server_compatability/balancedflight.js
@@ -1,0 +1,13 @@
+if(Platform.isLoaded("balancedflight")) {
+	onEvent('recipes', event => {
+	event.remove({ output: 'balancedflight:flight_anchor' })
+	event.recipes.createSequencedAssembly([
+	   'balancedflight:flight_anchor',
+	], 'minecraft:beacon', [
+		event.recipes.createDeploying(MC('beacon'), [MC('beacon'), KJ('inductive_mechanism')]),
+		event.recipes.createDeploying(MC('beacon'), [MC('beacon'), CR('railway_casing')]),
+		event.recipes.createDeploying(MC('beacon'), [MC('beacon'), CR('shaft')]),
+		event.recipes.createDeploying(MC('beacon'), [MC('beacon'), MC('elytra')]),
+	]).loops(1)
+  })
+}

--- a/overrides/kubejs/server_scripts/server_compatability/balancedflight.js
+++ b/overrides/kubejs/server_scripts/server_compatability/balancedflight.js
@@ -9,5 +9,10 @@ if(Platform.isLoaded("balancedflight")) {
 		event.recipes.createDeploying(MC('beacon'), [MC('beacon'), CR('shaft')]),
 		event.recipes.createDeploying(MC('beacon'), [MC('beacon'), MC('elytra')]),
 	]).loops(1)
+	event.replaceInput(
+		{ output: 'balancedflight:ascended_flight_ring' },
+		'minecraft:netherite_block',            
+		'kubejs:computation_matrix'
+	  )
   })
 }

--- a/overrides/kubejs/server_scripts/server_compatability/steampowered.js
+++ b/overrides/kubejs/server_scripts/server_compatability/steampowered.js
@@ -1,0 +1,49 @@
+if(Platform.isLoaded("steampowered")) {
+	onEvent('recipes', event => {
+
+    // Extended Gears already has metalic cogwheels, so Steam Powered cogs are redudant
+    // Craft & Additions already has two different alternators, so Steam Powered dynamo is redudant
+    event.remove({ mod: 'steampowered' })
+
+    // Burners
+    let burner = (output, metalBurner) => { 
+      event.shaped(output, [
+        'III',
+        'I I',
+        'BBB'
+      ], {
+        B: 'minecraft:bricks',
+        I: metalBurner
+      })
+    }
+    burner('steampowered:bronze_burner', 'alloyed:bronze_sheet')
+    burner('steampowered:cast_iron_burner', 'createdeco:cast_iron_sheet')
+    burner('steampowered:steel_burner', 'alloyed:steel_sheet')
+
+    // Boilers
+    let boiler = (output, metalBoiler) => {
+      event.shaped(output, [
+        ' M ',
+        'MTM',
+        ' M '
+      ], {
+        T: 'create:fluid_tank',
+        M: metalBoiler
+      })
+    }
+    boiler('steampowered:bronze_boiler', 'alloyed:bronze_sheet')
+    boiler('steampowered:cast_iron_boiler', 'createdeco:cast_iron_sheet')
+    boiler('steampowered:steel_boiler', 'alloyed:steel_sheet')
+
+    // Engines
+    brassMachine(event,Item.of('steampowered:bronze_steam_engine'), 'alloyed:bronze_block')
+		brassMachine(event,Item.of('steampowered:cast_iron_steam_engine'), 'createdeco:cast_iron_block')
+    brassMachine(event,Item.of('steampowered:steel_steam_engine'), 'alloyed:steel_block')
+
+    // Flywheels
+    event.smithing('steampowered:bronze_flywheel', 'create:flywheel', 'alloyed:bronze_block')
+    event.smithing('steampowered:cast_iron_flywheel', 'create:flywheel', 'createdeco:cast_iron_block')
+    event.smithing('steampowered:steel_flywheel', 'create:flywheel', 'alloyed:steel_block')
+  })
+}
+


### PR DESCRIPTION
**Describe the PR**
Changes Steam Powered recipes to make them more seamless with CABIN
- Removed recipes for: Metallic cogwheels, Dynamo & Pressurized containers
- Changed recipes for: Flywheels, Steam Engines, & Steam Boilers