### PR TITLE
Balanced Flight Compat

### DIFF
--- a/overrides/kubejs/server_scripts/server_compatability/balancedflight.js
+++ b/overrides/kubejs/server_scripts/server_compatability/balancedflight.js
@@ -1,0 +1,13 @@
+if(Platform.isLoaded("balancedflight")) {
+	onEvent('recipes', event => {
+	event.remove({ mod: 'balancedflight' })
+	event.recipes.createSequencedAssembly([
+	   'balancedflight:flight_anchor',
+	], 'minecraft:beacon', [
+		event.recipes.createDeploying(MC('beacon'), [MC('beacon'), KJ('inductive_mechanism')]),
+		event.recipes.createDeploying(MC('beacon'), [MC('beacon'), CR('railway_casing')]),
+		event.recipes.createDeploying(MC('beacon'), [MC('beacon'), CR('shaft')]),
+		event.recipes.createDeploying(MC('beacon'), [MC('beacon'), MC('elytra')]),
+	]).loops(1)
+  })
+}

--- a/overrides/kubejs/startup_scripts/startup_compatability/balancedflight.js
+++ b/overrides/kubejs/startup_scripts/startup_compatability/balancedflight.js
@@ -1,0 +1,4 @@
+// Magic Feather but Cooler
+if (Platform.isLoaded("createaddition")) {
+	global.itemBlacklist.push("balancedflight:ascended_flight_ring")
+}

--- a/overrides/kubejs/startup_scripts/startup_compatability/balancedflight.js
+++ b/overrides/kubejs/startup_scripts/startup_compatability/balancedflight.js
@@ -1,4 +1,4 @@
 // Magic Feather but Cooler
-if (Platform.isLoaded("createaddition")) {
+if (Platform.isLoaded("balancedflight")) {
 	global.itemBlacklist.push("balancedflight:ascended_flight_ring")
 }


### PR DESCRIPTION
**Describe the PR**
Changes Create Balanced Flight recipes in order to fit inside CABIN`s progression line.

Flight Anchor:
- Replaced Feather with Elytra
- Replaced Precision mechanism with Induction mechanism
- Miscellaneous tweaks to the rest of the recipe

Angel Ring:
- Removed (yikes)

**Additional context**

Making the anchor use an Elytra makes it be more in balance with the recipe of the Magic Feather, and making it use an induction mechanism makes it be tied to Chapter 4+.

Those changes were made in order to balance the anchor`s bigger AoE (When at full speed) compared to magic feather, also considering that only one elytra is required to make an anchor that grants flight to everyone inside its radius.

All these changes end up creating this new progression line:

- Magic Feather: Mid-game (Early-game if speedrunning, idk)
- Anchor: Late-Game & End-game