### PR TITLE
Steam Powered Compat

### DIFF
--- a/overrides/kubejs/server_scripts/server_compatability/steampowered.js
+++ b/overrides/kubejs/server_scripts/server_compatability/steampowered.js
@@ -10,12 +10,12 @@ if(Platform.isLoaded("steampowered")) {
         metalIngot
       ])
     }
-    cog('steampowered:bronze_cogwheel', 'create:shaft', 'alloyed:bronze_ingot')
-    cog('steampowered:cast_iron_cogwheel', 'create:shaft', 'createdeco:cast_iron_ingot')
-    cog('steampowered:steel_cogwheel', 'create:shaft', 'alloyed:steel_ingot')
-    cog('steampowered:bronze_large_cogwheel', 'steampowered:bronze_cogwheel', 'alloyed:bronze_ingot')
-    cog('steampowered:cast_iron_large_cogwheel', 'steampowered:cast_iron_cogwheel', 'createdeco:cast_iron_ingot')
-    cog('steampowered:steel_large_cogwheel', 'steampowered:steel_cogwheel', 'alloyed:steel_ingot')
+    cog('steampowered:bronze_cogwheel', 'create:shaft', '#forge:ingots/bronze')
+    cog('steampowered:cast_iron_cogwheel', 'create:shaft', '#forge:ingots/cast_iron')
+    cog('steampowered:steel_cogwheel', 'create:shaft', '#forge:ingots/steel')
+    cog('steampowered:bronze_large_cogwheel', 'steampowered:bronze_cogwheel', '#forge:ingots/bronze')
+    cog('steampowered:cast_iron_large_cogwheel', 'steampowered:cast_iron_cogwheel', '#forge:ingots/cast_iron')
+    cog('steampowered:steel_large_cogwheel', 'steampowered:steel_cogwheel', '#forge:ingots/steel')
     
     let largeCog = (output, metalIngot) => { 
       event.shapeless(output, [
@@ -24,9 +24,9 @@ if(Platform.isLoaded("steampowered")) {
         metalIngot
       ])
     }
-    largeCog('steampowered:bronze_large_cogwheel', 'alloyed:bronze_ingot')
-    largeCog('steampowered:cast_iron_large_cogwheel', 'createdeco:cast_iron_ingot')
-    largeCog('steampowered:steel_large_cogwheel', 'alloyed:steel_ingot')
+    largeCog('steampowered:bronze_large_cogwheel', '#forge:ingots/bronze')
+    largeCog('steampowered:cast_iron_large_cogwheel', '#forge:ingots/cast_iron')
+    largeCog('steampowered:steel_large_cogwheel', '#forge:ingots/steel')
 
     // Burners & Boilers
     let burner = (output, metalSheet) => { 
@@ -57,14 +57,12 @@ if(Platform.isLoaded("steampowered")) {
     boiler('steampowered:steel_boiler', 'alloyed:steel_sheet')
 
     // Engines & Flywheels
-    zincMachine(event,Item.of('steampowered:bronze_steam_engine'), 'alloyed:bronze_block')
-    zincMachine(event,Item.of('steampowered:cast_iron_steam_engine'), 'createdeco:cast_iron_block')
-    zincMachine(event,Item.of('steampowered:steel_steam_engine'), 'alloyed:steel_block')
+    zincMachine(event,Item.of('steampowered:bronze_steam_engine'), '#forge:storage_blocks/bronze')
+		zincMachine(event,Item.of('steampowered:cast_iron_steam_engine'), '#forge:storage_blocks/cast_iron')
+    zincMachine(event,Item.of('steampowered:steel_steam_engine'), '#forge:storage_blocks/steel')
 
-    createMachine('create:flywheel', event, 'steampowered:bronze_flywheel', 'alloyed:bronze_block')
-    createMachine('create:flywheel', event, 'steampowered:cast_iron_flywheel', 'createdeco:cast_iron_block')
-    createMachine('create:flywheel', event, 'steampowered:steel_flywheel', 'alloyed:steel_block')
+    createMachine('create:flywheel', event, 'steampowered:bronze_flywheel', '#forge:storage_blocks/bronze')
+    createMachine('create:flywheel', event, 'steampowered:cast_iron_flywheel', '#forge:storage_blocks/cast_iron')
+    createMachine('create:flywheel', event, 'steampowered:steel_flywheel', '#forge:storage_blocks/steel')
   })
 }
-
-

--- a/overrides/kubejs/server_scripts/server_compatability/steampowered.js
+++ b/overrides/kubejs/server_scripts/server_compatability/steampowered.js
@@ -1,49 +1,70 @@
 if(Platform.isLoaded("steampowered")) {
 	onEvent('recipes', event => {
 
-    // Extended Gears already has metalic cogwheels, so Steam Powered cogs are redundant
-    // Craft & Additions already has two different alternators, so Steam Powered dynamo is redudant
-    event.remove({ mod: 'steampowered' })
+    event.remove({ mod: 'steampowered' }) // The recipes are mostly outdated, reminiscent of Create 0.3
 
-    // Burners
-    let burner = (output, metalBurner) => { 
-      event.shaped(output, [
+    // Metallic Cogwheels
+    let cog = (output, base, metalIngot) => { 
+      event.shapeless(output, [
+        base,
+        metalIngot
+      ])
+    }
+    cog('steampowered:bronze_cogwheel', 'create:shaft', 'alloyed:bronze_ingot')
+    cog('steampowered:cast_iron_cogwheel', 'create:shaft', 'createdeco:cast_iron_ingot')
+    cog('steampowered:steel_cogwheel', 'create:shaft', 'alloyed:steel_ingot')
+    cog('steampowered:bronze_large_cogwheel', 'steampowered:bronze_cogwheel', 'alloyed:bronze_ingot')
+    cog('steampowered:cast_iron_large_cogwheel', 'steampowered:cast_iron_cogwheel', 'createdeco:cast_iron_ingot')
+    cog('steampowered:steel_large_cogwheel', 'steampowered:steel_cogwheel', 'alloyed:steel_ingot')
+    
+    let largeCog = (output, metalIngot) => { 
+      event.shapeless(output, [
+        'create:shaft',
+        metalIngot,
+        metalIngot
+      ])
+    }
+    largeCog('steampowered:bronze_large_cogwheel', 'alloyed:bronze_ingot')
+    largeCog('steampowered:cast_iron_large_cogwheel', 'createdeco:cast_iron_ingot')
+    largeCog('steampowered:steel_large_cogwheel', 'alloyed:steel_ingot')
+
+    // Burners & Boilers
+    let burner = (output, metalSheet) => { 
+      event.recipes.create.mechanical_crafting(output, [
         'III',
         'I I',
         'BBB'
       ], {
         B: 'minecraft:bricks',
-        I: metalBurner
+        I: metalSheet
       })
     }
     burner('steampowered:bronze_burner', 'alloyed:bronze_sheet')
     burner('steampowered:cast_iron_burner', 'createdeco:cast_iron_sheet')
     burner('steampowered:steel_burner', 'alloyed:steel_sheet')
 
-    // Boilers
-    let boiler = (output, metalBoiler) => {
-      event.shaped(output, [
-        ' M ',
+    let boiler = (output, metalSheet) => {
+      event.recipes.create.mechanical_crafting(output, [
+        'MM ',
         'MTM',
-        ' M '
+        ' MM'
       ], {
-        T: 'create:fluid_tank',
-        M: metalBoiler
+        T: 'create:fluid_tank', M: metalSheet
       })
     }
     boiler('steampowered:bronze_boiler', 'alloyed:bronze_sheet')
     boiler('steampowered:cast_iron_boiler', 'createdeco:cast_iron_sheet')
     boiler('steampowered:steel_boiler', 'alloyed:steel_sheet')
 
-    // Engines
+    // Engines & Flywheels
     brassMachine(event,Item.of('steampowered:bronze_steam_engine'), 'alloyed:bronze_block')
-		brassMachine(event,Item.of('steampowered:cast_iron_steam_engine'), 'createdeco:cast_iron_block')
+    brassMachine(event,Item.of('steampowered:cast_iron_steam_engine'), 'createdeco:cast_iron_block')
     brassMachine(event,Item.of('steampowered:steel_steam_engine'), 'alloyed:steel_block')
 
-    // Flywheels
     createMachine('create:flywheel', event, 'steampowered:bronze_flywheel', 'alloyed:bronze_block')
     createMachine('create:flywheel', event, 'steampowered:cast_iron_flywheel', 'createdeco:cast_iron_block')
     createMachine('create:flywheel', event, 'steampowered:steel_flywheel', 'alloyed:steel_block')
   })
 }
+
 

--- a/overrides/kubejs/server_scripts/server_compatability/steampowered.js
+++ b/overrides/kubejs/server_scripts/server_compatability/steampowered.js
@@ -57,9 +57,9 @@ if(Platform.isLoaded("steampowered")) {
     boiler('steampowered:steel_boiler', 'alloyed:steel_sheet')
 
     // Engines & Flywheels
-    brassMachine(event,Item.of('steampowered:bronze_steam_engine'), 'alloyed:bronze_block')
-    brassMachine(event,Item.of('steampowered:cast_iron_steam_engine'), 'createdeco:cast_iron_block')
-    brassMachine(event,Item.of('steampowered:steel_steam_engine'), 'alloyed:steel_block')
+    zincMachine(event,Item.of('steampowered:bronze_steam_engine'), 'alloyed:bronze_block')
+    zincMachine(event,Item.of('steampowered:cast_iron_steam_engine'), 'createdeco:cast_iron_block')
+    zincMachine(event,Item.of('steampowered:steel_steam_engine'), 'alloyed:steel_block')
 
     createMachine('create:flywheel', event, 'steampowered:bronze_flywheel', 'alloyed:bronze_block')
     createMachine('create:flywheel', event, 'steampowered:cast_iron_flywheel', 'createdeco:cast_iron_block')

--- a/overrides/kubejs/server_scripts/server_compatability/steampowered.js
+++ b/overrides/kubejs/server_scripts/server_compatability/steampowered.js
@@ -41,9 +41,9 @@ if(Platform.isLoaded("steampowered")) {
     brassMachine(event,Item.of('steampowered:steel_steam_engine'), 'alloyed:steel_block')
 
     // Flywheels
-    event.smithing('steampowered:bronze_flywheel', 'create:flywheel', 'alloyed:bronze_block')
-    event.smithing('steampowered:cast_iron_flywheel', 'create:flywheel', 'createdeco:cast_iron_block')
-    event.smithing('steampowered:steel_flywheel', 'create:flywheel', 'alloyed:steel_block')
+    createMachine('create:flywheel', event, 'steampowered:bronze_flywheel', 'alloyed:bronze_block')
+    createMachine('create:flywheel', event, 'steampowered:cast_iron_flywheel', 'createdeco:cast_iron_block')
+    createMachine('create:flywheel', event, 'steampowered:steel_flywheel', 'alloyed:steel_block')
   })
 }
 

--- a/overrides/kubejs/server_scripts/server_compatability/steampowered.js
+++ b/overrides/kubejs/server_scripts/server_compatability/steampowered.js
@@ -1,0 +1,49 @@
+if(Platform.isLoaded("steampowered")) {
+	onEvent('recipes', event => {
+
+    // Extended Gears already has metalic cogwheels, so Steam Powered cogs are redundant
+    // Craft & Additions already has two different alternators, so Steam Powered dynamo is redudant
+    event.remove({ mod: 'steampowered' })
+
+    // Burners
+    let burner = (output, metalBurner) => { 
+      event.shaped(output, [
+        'III',
+        'I I',
+        'BBB'
+      ], {
+        B: 'minecraft:bricks',
+        I: metalBurner
+      })
+    }
+    burner('steampowered:bronze_burner', 'alloyed:bronze_sheet')
+    burner('steampowered:cast_iron_burner', 'createdeco:cast_iron_sheet')
+    burner('steampowered:steel_burner', 'alloyed:steel_sheet')
+
+    // Boilers
+    let boiler = (output, metalBoiler) => {
+      event.shaped(output, [
+        ' M ',
+        'MTM',
+        ' M '
+      ], {
+        T: 'create:fluid_tank',
+        M: metalBoiler
+      })
+    }
+    boiler('steampowered:bronze_boiler', 'alloyed:bronze_sheet')
+    boiler('steampowered:cast_iron_boiler', 'createdeco:cast_iron_sheet')
+    boiler('steampowered:steel_boiler', 'alloyed:steel_sheet')
+
+    // Engines
+    brassMachine(event,Item.of('steampowered:bronze_steam_engine'), 'alloyed:bronze_block')
+		brassMachine(event,Item.of('steampowered:cast_iron_steam_engine'), 'createdeco:cast_iron_block')
+    brassMachine(event,Item.of('steampowered:steel_steam_engine'), 'alloyed:steel_block')
+
+    // Flywheels
+    event.smithing('steampowered:bronze_flywheel', 'create:flywheel', 'alloyed:bronze_block')
+    event.smithing('steampowered:cast_iron_flywheel', 'create:flywheel', 'createdeco:cast_iron_block')
+    event.smithing('steampowered:steel_flywheel', 'create:flywheel', 'alloyed:steel_block')
+  })
+}
+

--- a/overrides/kubejs/startup_scripts/startup_compatability/steampowered.js
+++ b/overrides/kubejs/startup_scripts/startup_compatability/steampowered.js
@@ -1,7 +1,9 @@
 // Steam Powered
 if (Platform.isLoaded("steampowered")) {
-	global.randomiumBlacklist.push("steampowered:pressurized_gas_container")
-	global.randomiumBlacklist.push("steampowered:pressurized_steam_container")
-	global.randomiumBlacklist.push("steampowered:bronze_sheet")
-	global.randomiumBlacklist.push("steampowered:alternator") // C:C&A Already has a better alternator, use that one instead
+	global.itemBlacklist.push("steampowered:pressurized_gas_container")
+	global.itemBlacklist.push("steampowered:pressurized_steam_container")
+	global.itemBlacklist.push("steampowered:bronze_sheet")
+	global.itemBlacklist.push("steampowered:alternator") // C:C&A Already has a better alternator, use that one instead
+
+    global.jeiFluidBlacklist.push('steampowered:steam_flowing')
 }

--- a/overrides/kubejs/startup_scripts/startup_compatability/steampowered.js
+++ b/overrides/kubejs/startup_scripts/startup_compatability/steampowered.js
@@ -1,14 +1,7 @@
 // Steam Powered
-if (Platform.isLoaded("createaddition")) {
-	global.itemBlacklist.push("steampowered:alternator")
-	global.itemBlacklist.push("steampowered:bronze_cogwheel")
-	global.itemBlacklist.push("steampowered:bronze_large_cogwheel")
-	global.itemBlacklist.push("steampowered:cast_iron_cogwheel")
-	global.itemBlacklist.push("steampowered:cast_iron_large_cogwheel")
-	global.itemBlacklist.push("steampowered:steel_cogwheel")
-	global.itemBlacklist.push("steampowered:steel_large_cogwheel")
-
+if (Platform.isLoaded("steampowered")) {
 	global.randomiumBlacklist.push("steampowered:pressurized_gas_container")
 	global.randomiumBlacklist.push("steampowered:pressurized_steam_container")
 	global.randomiumBlacklist.push("steampowered:bronze_sheet")
+	global.randomiumBlacklist.push("steampowered:alternator") // C:C&A Already has a better alternator, use that one instead
 }

--- a/overrides/kubejs/startup_scripts/startup_compatability/steampowered.js
+++ b/overrides/kubejs/startup_scripts/startup_compatability/steampowered.js
@@ -6,7 +6,7 @@ if (Platform.isLoaded("createaddition")) {
 	global.itemBlacklist.push("steampowered:cast_iron_cogwheel")
 	global.itemBlacklist.push("steampowered:cast_iron_large_cogwheel")
 	global.itemBlacklist.push("steampowered:steel_cogwheel")
-	global.itemBlacklist.push("steampowered:steell_large_cogwheel")
+	global.itemBlacklist.push("steampowered:steel_large_cogwheel")
 
 	global.randomiumBlacklist.push("steampowered:pressurized_gas_container")
 	global.randomiumBlacklist.push("steampowered:pressurized_steam_container")

--- a/overrides/kubejs/startup_scripts/startup_compatability/steampowered.js
+++ b/overrides/kubejs/startup_scripts/startup_compatability/steampowered.js
@@ -10,4 +10,5 @@ if (Platform.isLoaded("createaddition")) {
 
 	global.randomiumBlacklist.push("steampowered:pressurized_gas_container")
 	global.randomiumBlacklist.push("steampowered:pressurized_steam_container")
+	global.randomiumBlacklist.push("steampowered:bronze_sheet")
 }

--- a/overrides/kubejs/startup_scripts/startup_compatability/steampowered.js
+++ b/overrides/kubejs/startup_scripts/startup_compatability/steampowered.js
@@ -1,0 +1,13 @@
+// Steam Powered
+if (Platform.isLoaded("createaddition")) {
+	global.itemBlacklist.push("steampowered:alternator")
+	global.itemBlacklist.push("steampowered:bronze_cogwheel")
+	global.itemBlacklist.push("steampowered:bronze_large_cogwheel")
+	global.itemBlacklist.push("steampowered:cast_iron_cogwheel")
+	global.itemBlacklist.push("steampowered:cast_iron_large_cogwheel")
+	global.itemBlacklist.push("steampowered:steel_cogwheel")
+	global.itemBlacklist.push("steampowered:steell_large_cogwheel")
+
+	global.randomiumBlacklist.push("steampowered:pressurized_gas_container")
+	global.randomiumBlacklist.push("steampowered:pressurized_steam_container")
+}


### PR DESCRIPTION
Updates Steam Powered recipes to make them both fit more seamless with CABIN, and be in line with current versions of Create.

- Removed Dynamo & Pressurized containers
- Changed recipes of everything else
