### PR TITLE
Some tweaks to the Create Connected Compat

### DIFF
--- a/overrides/kubejs/server_scripts/server_compatability/create_connected.js
+++ b/overrides/kubejs/server_scripts/server_compatability/create_connected.js
@@ -1,8 +1,7 @@
 if(Platform.isLoaded("create_connected")) {
 	onEvent('recipes', event => {
-    event.remove({ output: 'create_connected:control_chip' })
-    event.remove({ output: 'create_connected:sequenced_pulse_generator' })
+        event.remove({ id: 'create_connected:sequenced_assembly/control_chip' })
 
-    event.smithing('create_connected:sequenced_pulse_generator', 'projectred_core:platformed_plate', 'create:electron_tube')
+        createMachine('projectred_core:platformed_plate', event, 'create_connected:sequenced_pulse_generator', 'create:electron_tube')
 	})
 }

--- a/overrides/kubejs/startup_scripts/startup_compatability/create_connected.js
+++ b/overrides/kubejs/startup_scripts/startup_compatability/create_connected.js
@@ -1,0 +1,7 @@
+//Crafts and Additions
+if (Platform.isLoaded("create_connected")) {
+	global.itemBlacklist.push("create_connected:control_chip")
+	global.itemBlacklist.push("create_connected:incomplete_control_chip")
+
+	global.randomiumBlacklist.push("create_connected:creative_fluid_vessel")
+}

--- a/overrides/kubejs/startup_scripts/startup_compatability/createaddition.js
+++ b/overrides/kubejs/startup_scripts/startup_compatability/createaddition.js
@@ -8,6 +8,8 @@ if (Platform.isLoaded("createaddition")) {
 	//Unfortunately we have stick to thermal diamond dust due to the strainer recipe
 	global.itemBlacklist.push("createaddition:diamond_grit")
 	global.itemBlacklist.push("createaddition:accumulator")
+
+	global.randomiumBlacklist.push("createaddition:creative_energy")
 }
 
 //Sequence assembly items


### PR DESCRIPTION
Minor tweaks to the create connected Compat, hide unused items from rei and blacklist the creative item.
Also fixes the Creative Generator from the crafts and additions compat not being blacklisted from randomium ore