### PR TITLE
Create Encased Compat

### DIFF
--- a/overrides/config/createcasing-common.toml
+++ b/overrides/config/createcasing-common.toml
@@ -1,0 +1,18 @@
+
+#.
+#Modify Create Encased blocks comportements
+[kinetics]
+	#.
+	#Should Brass/Copper/Train mixe faster
+	shouldCustomMixerMixeFaster = false
+	#.
+	#Should Wooden Shaft break if the speed is too high
+	shouldWoodenShaftBreak = true
+	#.
+	#Should Glass Shaft break if the system is overstressed
+	shouldGlassShaftBreak = true
+	#.
+	#The max speed wooden shafts can endure
+	#Range: 2 ~ 256
+	maxSpeedWoodenShaft = 32
+

--- a/overrides/kubejs/server_scripts/server_compatability/createcasing.js
+++ b/overrides/kubejs/server_scripts/server_compatability/createcasing.js
@@ -2,22 +2,8 @@
 if(Platform.isLoaded("createcasing")) {
   onEvent('item.tags', event => {
 
-    // Custom Tags
-    event.add('cabin:encased_mixers',
-      'createcasing:brass_mixer',
-      'createcasing:copper_mixer',
-      'createcasing:industrial_iron_mixer',
-      'createcasing:railway_mixer',
-      'createcasing:creative_mixer')
-
-    event.add('cabin:encased_presses',
-      'createcasing:brass_press',
-      'createcasing:copper_press',
-      'createcasing:industrial_iron_press',
-      'createcasing:railway_press',
-      'createcasing:creative_press')
-
-    event.add('cabin:encased_shafts',
+    // Custom Tag
+    event.add('createcasing:shafts',
       'createcasing:oak_shaft',
       'createcasing:spruce_shaft',
       'createcasing:birch_shaft',
@@ -30,13 +16,12 @@ if(Platform.isLoaded("createcasing")) {
       'createcasing:glass_shaft',
       'createcasing:mldeg_shaft')
   })
-
-	onEvent('recipes', event => {
+   onEvent('recipes', event => {
 
     // Cleanup
-    event.remove({ output: '#cabin:encased_mixers'})
-    event.remove({ output: '#cabin:encased_presses'})
-    event.remove({ output: '#cabin:encased_shafts'}) // Most of them are useless, and somewhat buggy
+    event.remove({ input: 'create:whisk', mod: 'createcasing'}) // Breaks Progression
+    event.remove({ input: 'miencraft:iron_block', mod: 'createcasing'}) // Same as Above
+    event.remove({ output: '#createcasing:shafts', mod: 'createcasing'}) // Most of them are useless, and somewhat buggy
 
     // Mixers
     let mixer = (output, sheet) => { 

--- a/overrides/kubejs/server_scripts/server_compatability/createcasing.js
+++ b/overrides/kubejs/server_scripts/server_compatability/createcasing.js
@@ -1,0 +1,86 @@
+if(Platform.isLoaded("createcasing")) {
+  onEvent('item.tags', event => {
+
+    // Custom Tags
+    event.add('cabin:encased_mixers',
+      'createcasing:brass_mixer',
+      'createcasing:copper_mixer',
+      'createcasing:industrial_iron_mixer',
+      'createcasing:railway_mixer',
+      'createcasing:creative_mixer')
+
+    event.add('cabin:encased_presses',
+      'createcasing:brass_press',
+      'createcasing:copper_press',
+      'createcasing:industrial_iron_press',
+      'createcasing:railway_press',
+      'createcasing:creative_press')
+
+    event.add('cabin:encased_shafts',
+      'createcasing:oak_shaft',
+      'createcasing:spruce_shaft',
+      'createcasing:birch_shaft',
+      'createcasing:jungle_shaft',
+      'createcasing:acacia_shaft',
+      'createcasing:dark_oak_shaft',
+      'createcasing:crimson_shaft',
+      'createcasing:warped_shaft',
+      'createcasing:brass_shaft',
+      'createcasing:glass_shaft',
+      'createcasing:mldeg_shaft')
+  })
+
+	onEvent('recipes', event => {
+
+    // Cleanup
+    event.remove({ output: '#cabin:encased_mixers'})
+    event.remove({ output: '#cabin:encased_presses'})
+    event.remove({ output: '#cabin:encased_shafts'}) // Most of them are useless, and somewhat buggy
+
+    // Mixers
+    let mixer = (output, sheet) => { 
+      event.shapeless(output, [
+        'create:mechanical_mixer',
+        sheet
+      ])
+    }
+    mixer('createcasing:brass_mixer', 'create:brass_sheet')
+    mixer('createcasing:copper_mixer', 'create:copper_sheet')
+    mixer('createcasing:industrial_iron_mixer', 'create:iron_sheet')
+    mixer('createcasing:railway_mixer', 'create:golden_sheet')
+    mixer('createcasing:creative_mixer', 'createcasing:chorium_ingot')
+
+    // Presses
+    let press = (output, sheet) => { 
+      event.shapeless(output, [
+        'create:mechanical_press',
+        sheet
+      ])
+    }
+    press('createcasing:brass_press', 'create:brass_sheet')
+    press('createcasing:copper_press', 'create:copper_sheet')
+    press('createcasing:industrial_iron_press', 'create:iron_sheet')
+    press('createcasing:railway_press', 'create:golden_sheet')
+    press('createcasing:creative_press', 'createcasing:chorium_ingot')
+
+    // Depots
+    let depot = (recipeID, ingot) => {
+    event.replaceInput(
+      {id: recipeID},
+      'create:andesite_alloy',
+      ingot
+    )}
+    depot('createcasing:crafting/depot/brass', 'create:brass_sheet')
+    depot('createcasing:crafting/depot/copper', 'create:copper_sheet')
+    depot('createcasing:crafting/depot/industrial_iron', 'create:iron_sheet')
+    depot('createcasing:crafting/depot/railway', 'create:golden_sheet')
+    depot('createcasing:crafting/depot/creative', 'createcasing:chorium_ingot')
+    
+    // Adjustable Chain Gearshifts
+    event.replaceInput(
+      { input: 'create:electron_tube', mod: 'createcasing' },
+      'create:electron_tube',
+      'minecraft:redstone'
+    )
+  })
+}

--- a/overrides/kubejs/server_scripts/server_compatability/createcasing.js
+++ b/overrides/kubejs/server_scripts/server_compatability/createcasing.js
@@ -20,7 +20,7 @@ if(Platform.isLoaded("createcasing")) {
 
     // Cleanup
     event.remove({ input: 'create:whisk', mod: 'createcasing'}) // Breaks Progression
-    event.remove({ input: 'miencraft:iron_block', mod: 'createcasing'}) // Same as Above
+    event.remove({ input: 'minecraft:iron_block', mod: 'createcasing'}) // Same as Above
     event.remove({ output: '#createcasing:shafts', mod: 'createcasing'}) // Most of them are useless, and somewhat buggy
 
     // Mixers

--- a/overrides/kubejs/server_scripts/server_compatability/createcasing.js
+++ b/overrides/kubejs/server_scripts/server_compatability/createcasing.js
@@ -1,27 +1,13 @@
 // Create Encased
 if(Platform.isLoaded("createcasing")) {
-  onEvent('item.tags', event => {
-
-    // Custom Tag
-    event.add('createcasing:shafts',
-      'createcasing:oak_shaft',
-      'createcasing:spruce_shaft',
-      'createcasing:birch_shaft',
-      'createcasing:jungle_shaft',
-      'createcasing:acacia_shaft',
-      'createcasing:dark_oak_shaft',
-      'createcasing:crimson_shaft',
-      'createcasing:warped_shaft',
-      'createcasing:brass_shaft',
-      'createcasing:glass_shaft',
-      'createcasing:mldeg_shaft')
-  })
-   onEvent('recipes', event => {
+	onEvent('recipes', event => {
 
     // Cleanup
-    event.remove({ input: 'create:whisk', mod: 'createcasing'}) // Breaks Progression
-    event.remove({ input: 'minecraft:iron_block', mod: 'createcasing'}) // Same as Above
-    event.remove({ output: '#createcasing:shafts', mod: 'createcasing'}) // Most of them are useless, and somewhat buggy
+    event.remove({ input: 'minecraft:iron_block', mod: 'createcasing'}) // Removes Presses
+    event.remove({ input: 'create:whisk', mod: 'createcasing'}) // Removes Mixers
+    event.remove({ input: '#forge:stripped_logs', mod: 'createcasing'}) // Removes Wooden Shaffs
+    event.remove({ input: 'create:brass_ingot', mod: 'createcasing'}) // Removes Brass Shaft
+    event.remove({ input: 'minecraft:glass', mod: 'createcasing'}) // Removes Glass Shaft
 
     // Mixers
     let mixer = (output, sheet) => { 

--- a/overrides/kubejs/server_scripts/server_compatability/createcasing.js
+++ b/overrides/kubejs/server_scripts/server_compatability/createcasing.js
@@ -1,3 +1,4 @@
+// Create Encased
 if(Platform.isLoaded("createcasing")) {
   onEvent('item.tags', event => {
 

--- a/overrides/kubejs/startup_scripts/startup_compatability/createcasing.js
+++ b/overrides/kubejs/startup_scripts/startup_compatability/createcasing.js
@@ -1,5 +1,16 @@
 // Create Encased
 if (Platform.isLoaded("createcasing")) {
-	global.itemBlacklist.push("#cabin:encased_shafts")
+	global.itemBlacklist.push("oak_shaft")
+	global.itemBlacklist.push("spruce_shaft")
+	global.itemBlacklist.push("birch_shaft")
+	global.itemBlacklist.push("jungle_shaft")
+	global.itemBlacklist.push("acacia_shaft")
+	global.itemBlacklist.push("dark_oak_shaft")
+	global.itemBlacklist.push("crimson_shaft")
+	global.itemBlacklist.push("warped_shaft")
+	global.itemBlacklist.push("glass_shaft")
+	global.itemBlacklist.push("brass_shaft")
+	
 	global.randomiumBlacklist.push("createcasing:creative_cogwheel")
+	global.randomiumBlacklist.push("createcasing:mldeg_shaft")
 }

--- a/overrides/kubejs/startup_scripts/startup_compatability/createcasing.js
+++ b/overrides/kubejs/startup_scripts/startup_compatability/createcasing.js
@@ -1,0 +1,5 @@
+// Create Encased
+if (Platform.isLoaded("createcasing")) {
+	global.itemBlacklist.push("#cabin:encased_shafts")
+	global.randomiumBlacklist.push("createcasing:creative_cogwheel")
+}


### PR DESCRIPTION
**Describe the PR**
- Changed recipes for Mixers and Presses in order to not break early game progression
- Removed Shafts added by Create Encased
- Minor recipe changes to Depots and Adjustable Gearshifts

**Additional context**
There`s known incompatibilities between Create Encased and Create Extended Cogwheels:
- Cogs from both mods do not render correctly when both mods are installed
- Encased Cogs override Extended Half & Shaftless Cogs when manually applying wooden planks
- A shitton of rendering Issues when using Shaders

I would suggest adding a script that warns the player when both mods are installed