### PR TITLE
tinygates compat

### DIFF
--- a/overrides/kubejs/server_scripts/mods/projectred_transmission.js
+++ b/overrides/kubejs/server_scripts/mods/projectred_transmission.js
@@ -3,6 +3,6 @@ if (Platform.isLoaded('projectred_transmission')) {
 	onEvent('recipes', event => {
 		event.remove({ id: 'projectred_transmission:wired_plate' })
 		event.remove({ id: 'projectred_transmission:bundled_plate' })
-		event.replaceInput({ id:'kubejs:platformed_plate' }, PR_C('red_ingot'), PR_T('red_alloy_wire'))
+		event.shapeless(PR_C('platformed_plate'), [PR_C('plate'), PR_T('red_alloy_wire'), CR("andesite_alloy")]).id('kubejs:platformed_plate')
 	})
 }

--- a/overrides/kubejs/server_scripts/server_compatability/tinygates.js
+++ b/overrides/kubejs/server_scripts/server_compatability/tinygates.js
@@ -1,0 +1,16 @@
+if (Platform.isLoaded('tinygates')) {
+	//ProjectRed Integration alternative
+	onEvent('recipes', event => {	
+		let tg_circuit = (id) => event.stonecutting(Item.of("tinygates:" + id + "_item", 1), PR_C('platformed_plate'))
+		event.remove({ mod:'tinygates' })
+		tg_circuit('and_gate')
+		tg_circuit('clock')
+		tg_circuit('counter')
+		tg_circuit('edge_detector')
+		tg_circuit('not_gate')
+		tg_circuit('or_gate')
+		tg_circuit('rs_latch')
+		tg_circuit('t_flip_flop')
+		tg_circuit('xor_gate')
+	})
+}


### PR DESCRIPTION
Adds compatability for the tinygates mod (projectred integration alternative)
Also fixes the platformed plate recipe using red alloy ingot instead of wire even when ProjectRed Transmission is still installed