### PR TITLE
Update lifesavers.snbt

### DIFF
--- a/overrides/config/ftbquests/quests/chapters/lifesavers.snbt
+++ b/overrides/config/ftbquests/quests/chapters/lifesavers.snbt
@@ -782,6 +782,7 @@
 				id: "09FD6301B7CF206E"
 				type: "item"
 				item: "thermal:fluid_duct"
+				consume_items: false
 			}]
 			rewards: [{
 				id: "3A35387B6A431842"
@@ -866,6 +867,7 @@
 					Count: 1b
 					tag: { }
 				}
+				consume_items: false
 			}]
 			rewards: [{
 				id: "65589D633E5A9F73"


### PR DESCRIPTION
Fixed fluid duct and chisel quest to not consume the item upon completion

**Describe the PR**
Set the consume_items variable to false for the two mentioned quests.

**Screenshots**
If applicable, add screenshots.

**Additional context**
Add any other context about the PR here.
