### PR TITLE
manual sanding of rose_quartz, overview bonus 1a quest fix

### DIFF
--- a/overrides/config/ftbquests/quests/chapters/overview.snbt
+++ b/overrides/config/ftbquests/quests/chapters/overview.snbt
@@ -120,7 +120,6 @@
 		}
 		{
 			title: "Copper Machinery"
-			disable_toast: true
 			x: -8.0d
 			y: 2.5d
 			subtitle: "Utility"
@@ -131,16 +130,15 @@
 			]
 			dependencies: [
 				"7D872F933F45809B"
-				"6545C3F427B12106"
+				"0E0535849D8D9279"
 			]
 			id: "342BB6EF80EBFDCA"
 			tasks: [{
 				id: "27B07858A6018539"
 				type: "stat"
-				title: "Complete Bonus 1A"
+				title: "Completed Bonus 1A"
 				icon: "kubejs:sealed_mechanism"
-				disable_toast: true
-				stat: "minecraft:play_one_minute"
+				stat: "minecraft:play_time"
 				value: 1
 			}]
 		}

--- a/overrides/kubejs/server_scripts/recipes/chapters.js
+++ b/overrides/kubejs/server_scripts/recipes/chapters.js
@@ -262,8 +262,8 @@ onEvent('recipes', event => {
 	event.remove({ id: CR('milling/compat/ae2/certus_quartz') })
 	event.remove({ id: CR('crafting/materials/electron_tube') })
 	event.remove({ id: CR('crafting/materials/rose_quartz') })
-	event.remove({ id: CR('sandpaper_polishing/rose_quartz') })
-	event.remove({ id: CR('sandpaper_polishing/rose_quartz') })
+	//event.remove({ id: CR('sandpaper_polishing/rose_quartz') })
+	//event.remove({ id: CR('sandpaper_polishing/rose_quartz') })
 
 	{ //This is a part of the chapter 2 script for some reason
 		let redstoneTransmute = (input, output) => {


### PR DESCRIPTION
**Describe the PR**
If the goal is to stay as true to the original as possible, the sandpaper_polishing recipe should be allowed for rose_quartz.

Changed "Completed Bonus 1A" in the "Overview" chapter to correctly complete when you finished the corresponding quest inside the "1 High Aspirations" chapter. (It now functions the exactly the same as the "Completed Bonus 1B" counterpart).

**Screenshots**
If applicable, add screenshots.

**Additional context**
Add any other context about the PR here.
