### PR TITLE
Improve reliquary

### DIFF
--- a/overrides/kubejs/server_scripts/mods/reliquary.js
+++ b/overrides/kubejs/server_scripts/mods/reliquary.js
@@ -34,8 +34,8 @@ if(Platform.isLoaded("reliquary")) {
 		event.recipes.createMixing(RQ('angelic_feather'),[F('#feathers'),RQ('nebulous_heart'),RQ('bat_wing'),Fluid.of(KJ('fertile_potion'),vialAmount)])
 		if (Platform.isLoaded("sliceanddice")){
 			event.recipes.create.mixing(
-				[Fluid.of('minecraft:water',216),Fluid.of('kubejs:fertile_potion',24)],
-				[Fluid.of('sliceanddice:fertilizer',240)]
+				[Fluid.of('sliceanddice:fertilizer',240)],
+				[Fluid.of('kubejs:fertile_potion',24),Fluid.of('minecraft:water',216)]
 			)
 		}
 
@@ -57,89 +57,68 @@ if(Platform.isLoaded("reliquary")) {
 				], rib)
 			}
 		}
+		let crushing = (outputs, input) => {
+			event.recipes.createMilling(outputs,input)
+			if(Platform.isLoaded('thermal')){event.recipes.thermal.pulverizer(outputs,input)}
+		}
+		let melting = (output, input, temp, time) => {
+			if(Platform.isLoaded('thermal')){event.recipes.thermal.crucible(output[0],input)}
+			if(Platform.isLoaded("tconstruct")){
+				var recipe = {
+					"type":"tconstruct:melting",
+					"ingredient":{item:input},
+					"result": output.shift().toJson(),
+					"temperature": temp,
+					"time": time
+				}
+				//Sadly, tcon doesn't want our empty byproducts array :(
+				if(output.length>0){recipe["byproducts"] = output.map(element => element.toJson())}
+				event.custom(recipe)
+			}
+		}
 		boneProcess(RQ('rib_bone'), MC('bone'), MC('white_dye'))
-		event.recipes.createMilling([MC('gunpowder',8)],RQ('catalyzing_gland'))
-		event.recipes.createMilling([MC('gunpowder',12)],RQ('eye_of_the_storm'))
-		event.recipes.createMilling([MC('snowball',6)],RQ('frozen_core'))
-		event.recipes.createMilling(['4x ae2:ender_dust'],RQ('nebulous_heart'))
-		event.recipes.createMilling([MC('prismarine_shard',6)],RQ('guardian_spike'))
-		event.recipes.createMilling([MC('black_dye',15),MC('gray_dye')],RQ('squid_beak'))
+		crushing([MC('gunpowder',8)],RQ('catalyzing_gland'))
+		crushing([MC('gunpowder',12)],RQ('eye_of_the_storm'))
+		crushing([MC('snowball',6)],RQ('frozen_core'))
+		crushing(['4x ae2:ender_dust'],RQ('nebulous_heart'))
+		crushing([MC('prismarine_shard',6)],RQ('guardian_spike'))
+		crushing([MC('black_dye',15),MC('gray_dye')],RQ('squid_beak'))
+		crushing([MC('rotten_flesh',8)],RQ('zombie_heart'))
+		melting([Fluid.of(TC('earth_slime'),1500)],RQ('slime_pearl'),50,60)
+		melting([Fluid.of(TC('blazing_blood'),150),Fluid.of(TC('magma'),500)],RQ('molten_core'),300,92)
+		melting([Fluid.of(TC('molten_ender'),1000)],RQ('nebulous_heart'),477,160)
+		melting([Fluid.of(TC('powdered_snow'),500)],RQ('frozen_core'),0,80)
+		melting([Fluid.of(TC('molten_gold'),30),Fluid.of(TC('blood'),150)],RQ('zombie_heart'),700,60)
+		if(Platform.isLoaded("tconstruct")){boneProcess(RQ('withered_rib'),TC('necrotic_bone'),MC('black_dye'))
+			event.recipes.minecraft.stonecutting('5x minecraft:bone',RQ('withered_rib'))
+		}
+		if(Platform.isLoaded('create_enchantment_industry')){melting([Fluid.of('create_enchantment_industry:ink',4000)],RQ('squid_beak'),75,60)}
+		if(Platform.isLoaded('thermal')){event.custom({"type": "thermal:crystallizer",
+			"ingredients": [
+				{
+					"fluid": "minecraft:water",
+					"amount": 2000
+				},
+				{"item": "reliquary:guardian_spike"}
+			],
+			"result": [{
+				"item":'minecraft:prismarine_crystals',
+				"count":6
+			}]
+		})}
 		if(Platform.isLoaded("createaddition")){//Rolling
-			event.custom({"type":"createaddition:rolling",
-				"input": {"item": "reliquary:chelicerae"},
+			event.custom({"type":"createaddition:rolling","input": {"item": "reliquary:chelicerae"},
 				"result": {
 					"item": "minecraft:string",
 					"count": 8
 				}
 			})
-			event.custom({"type":"createaddition:rolling",
-				"input": {"item": "reliquary:molten_core"},
+			event.custom({"type":"createaddition:rolling","input": {"item": "reliquary:molten_core"},
 				"result": {
 					"item": "minecraft:blaze_rod",
 					"count": 2
 				}
 			})
-		}
-		if(Platform.isLoaded("tconstruct")){//Melting, necrotic bones
-			event.custom({"type": "tconstruct:melting",
-				"ingredient": {"item": "reliquary:slime_pearl"},
-				"result": {
-					"fluid": "tconstruct:earth_slime",
-					"amount": 1500
-				},
-				"temperature": 50,
-				"time": 60
-			})
-			event.custom({"type": "tconstruct:melting",
-				"ingredient": {"item": "reliquary:molten_core"},
-				"result": {
-					"fluid": "tconstruct:magma",
-					"amount": 750
-				},
-				"temperature": 300,
-				"time": 92
-			})
-			event.custom({"type": "tconstruct:melting",
-				"ingredient": {"item": "reliquary:nebulous_heart"},
-				"result": {
-					"fluid": "tconstruct:molten_ender",
-					"amount": 1000
-				},
-				"temperature": 477,
-				"time": 160
-			})
-			event.custom({"type": "tconstruct:melting",
-				"ingredient": {"item": "reliquary:frozen_core"},
-				"result": {
-					"fluid": "tconstruct:powdered_snow",
-					"amount": 500
-				},
-				"temperature": 0,
-				"time": 80
-			})
-			boneProcess(RQ('withered_rib'),TC('necrotic_bone'),MC('black_dye'))
-			event.recipes.minecraft.stonecutting('5x minecraft:bone',RQ('withered_rib'))
-		}
-		if(Platform.isLoaded('thermal')){//Crystallizer
-			event.custom({"type": "thermal:crystallizer",
-				"ingredients": [
-					{
-						"fluid": "minecraft:water",
-						"amount": 2000
-					},
-					{"item": "reliquary:guardian_spike"}
-				],
-				"result": [{
-					"item":'minecraft:prismarine_crystals',
-					"count":6
-				}]
-			})
-			event.recipes.thermal.pulverizer([MC('gunpowder',8)],RQ('catalyzing_gland'))
-			event.recipes.thermal.pulverizer([MC('gunpowder',12)],RQ('eye_of_the_storm'))
-			event.recipes.thermal.pulverizer([MC('snowball',6)],RQ('frozen_core'))
-			event.recipes.thermal.pulverizer(['4x ae2:ender_dust'],RQ('nebulous_heart'))
-			event.recipes.thermal.pulverizer([MC('prismarine_shard',6)],RQ('guardian_spike'))
-			event.recipes.thermal.pulverizer([MC('black_dye',15),MC('gray_dye')],RQ('squid_beak'))
 		}
 	})
 }

--- a/overrides/kubejs/server_scripts/mods/reliquary.js
+++ b/overrides/kubejs/server_scripts/mods/reliquary.js
@@ -10,8 +10,8 @@ if(Platform.isLoaded("reliquary")) {
 		let vials = ['glowing_water','angelheart_vial','aphrodite_potion','fertile_potion']
 		let ingredients = [
 			[Fluid.of(MC('water'),vialAmount),MC('glowstone_dust'),MC('nether_wart'),MC('gunpowder')],
-			[Fluid.of(MC('milk'),vialAmount),RQ('infernal_claw'),RQ('fertile_essence',2)],
-			[Fluid.of(MC('water'),vialAmount),RQ('fertile_essence'),MC('red_dye'),MC('cocoa_beans')],
+			[Fluid.of(KJ('fertile_potion'),vialAmount*2),RQ('infernal_claw')],
+			[Fluid.of(KJ('fertile_potion'),vialAmount),MC('red_dye'),MC('cocoa_beans')],
 			[Fluid.of(MC('water'),vialAmount),RQ('slime_pearl'),RQ('catalyzing_gland'),RQ('rib_bone')]
 		]
 		for (let i = 0; i < vials.length; i++) {
@@ -22,7 +22,7 @@ if(Platform.isLoaded("reliquary")) {
 		}
 
 		//Recipes
-		event.recipes.createFilling(RQ('glowing_bread'),[F('#bread'),Fluid.of(KJ('fertile_potion'),vialAmount/3)])
+		event.recipes.createFilling(RQ('glowing_bread'),[F('#bread'),Fluid.of(KJ('glowing_water'),vialAmount/3)])
 		event.recipes.createMixing(RQ('holy_hand_grenade',4),[Fluid.of(KJ('glowing_water'),vialAmount),MC('gold_nugget'),MC('tnt'),RQ('catalyzing_gland')])
 
 		event.recipes.createFilling(RQ('phoenix_down'), [RQ('angelic_feather'),Fluid.of(KJ('angelheart_vial'),vialAmount*3)])
@@ -31,6 +31,95 @@ if(Platform.isLoaded("reliquary")) {
 		event.recipes.createEmptying([MC('green_dye'),Fluid.of(KJ('fertile_potion'),vialAmount)], RQ('fertile_essence'))
 		event.recipes.createMixing(RQ('witherless_rose'),[MC('rose_bush'),Fluid.of(KJ('fertile_potion'),vialAmount*4),F('#nether_stars',4)])
 		event.recipes.createFilling(RQ('fertile_lily_pad'),[MC('lily_pad'),Fluid.of(KJ('fertile_potion'),vialAmount*3)])
+		event.recipes.createMixing(RQ('angelic_feather'),[F('#feathers'),RQ('nebulous_heart'),RQ('bat_wing'),Fluid.of(KJ('fertile_potion'),vialAmount)])
 
+		//Mob drops
+		event.remove({id:"reliquary:uncrafting/bone"})
+		let boneProcess = (rib, bone, dye) => {
+			event.shapeless(`3x ${bone}`,[rib])
+			event.recipes.createCutting(`5x ${bone}`,rib)
+			event.recipes.createMilling([
+				MC('bone_meal',15),
+				Item.of(dye).withCount(5).withChance(0.40),
+				Item.of(MC('bone_meal',15)).withChance(0.40)
+			], rib)
+		}
+		boneProcess(RQ('rib_bone'), MC('bone'), MC('white_dye'))
+		boneProcess(RQ('withered_rib'),TC('necrotic_bone'),MC('black_dye'))
+		event.recipes.createMilling([MC('gunpowder',8)],RQ('catalyzing_gland'))
+		event.recipes.createMilling([MC('gunpowder',12)],RQ('eye_of_the_storm'))
+		event.recipes.createMilling([MC('snowball',6)],RQ('frozen_core'))
+		event.recipes.createMilling(['4x ae2:ender_dust'],RQ('nebulous_heart'))
+		event.recipes.createMilling([MC('prismarine_shard',6)],RQ('guardian_spike'))
+		event.recipes.createMilling([MC('black_dye',15),MC('gray_dye')],RQ('squid_beak'))
+		if(Platform.isLoaded("createaddition")){//Rolling
+			event.custom({"type":"createaddition:rolling",
+				"input": {"item": "reliquary:chelicerae"},
+				"result": {
+					"item": "minecraft:string",
+					"count": 8
+				}
+			})
+			event.custom({"type":"createaddition:rolling",
+				"input": {"item": "reliquary:molten_core"},
+				"result": {
+					"item": "minecraft:blaze_rod",
+					"count": 2
+				}
+			})
+		}
+		if(Platform.isLoaded("tconstruct")){//Melting
+			event.custom({"type": "tconstruct:melting",
+				"ingredient": {"item": "reliquary:slime_pearl"},
+				"result": {
+					"fluid": "tconstruct:earth_slime",
+					"amount": 1500
+				},
+				"temperature": 50,
+				"time": 60
+			})
+			event.custom({"type": "tconstruct:melting",
+				"ingredient": {"item": "reliquary:molten_core"},
+				"result": {
+					"fluid": "tconstruct:magma",
+					"amount": 750
+				},
+				"temperature": 300,
+				"time": 92
+			})
+			event.custom({"type": "tconstruct:melting",
+				"ingredient": {"item": "reliquary:nebulous_heart"},
+				"result": {
+					"fluid": "tconstruct:molten_ender",
+					"amount": 1000
+				},
+				"temperature": 477,
+				"time": 160
+			})
+			event.custom({"type": "tconstruct:melting",
+				"ingredient": {"item": "reliquary:frozen_core"},
+				"result": {
+					"fluid": "tconstruct:powdered_snow",
+					"amount": 500
+				},
+				"temperature": 0,
+				"time": 80
+			})
+		}
+		if(Platform.isLoaded('thermal')){//Crystallizer
+			event.custom({"type": "thermal:crystallizer",
+				"ingredients": [
+					{
+						"fluid": "minecraft:water",
+						"amount": 2000
+					},
+					{"item": "reliquary:guardian_spike"}
+				],
+				"result": [{
+					"item":'minecraft:prismarine_crystals',
+					"count":6
+				}]
+			})
+		}
 	})
 }

--- a/overrides/kubejs/server_scripts/mods/reliquary.js
+++ b/overrides/kubejs/server_scripts/mods/reliquary.js
@@ -37,7 +37,7 @@ if(Platform.isLoaded("reliquary")) {
 		event.remove({id:"reliquary:uncrafting/bone"})
 		let boneProcess = (rib, bone, dye) => {
 			event.shapeless(`3x ${bone}`,[rib])
-			event.recipes.createCutting(`5x ${bone}`,rib)
+			event.stonecutting(`5x ${bone}`,rib)
 			event.recipes.createMilling([
 				MC('bone_meal',15),
 				Item.of(dye).withCount(5).withChance(0.40),
@@ -45,7 +45,6 @@ if(Platform.isLoaded("reliquary")) {
 			], rib)
 		}
 		boneProcess(RQ('rib_bone'), MC('bone'), MC('white_dye'))
-		boneProcess(RQ('withered_rib'),TC('necrotic_bone'),MC('black_dye'))
 		event.recipes.createMilling([MC('gunpowder',8)],RQ('catalyzing_gland'))
 		event.recipes.createMilling([MC('gunpowder',12)],RQ('eye_of_the_storm'))
 		event.recipes.createMilling([MC('snowball',6)],RQ('frozen_core'))
@@ -68,7 +67,7 @@ if(Platform.isLoaded("reliquary")) {
 				}
 			})
 		}
-		if(Platform.isLoaded("tconstruct")){//Melting
+		if(Platform.isLoaded("tconstruct")){//Melting, necrotic bones
 			event.custom({"type": "tconstruct:melting",
 				"ingredient": {"item": "reliquary:slime_pearl"},
 				"result": {
@@ -105,6 +104,8 @@ if(Platform.isLoaded("reliquary")) {
 				"temperature": 0,
 				"time": 80
 			})
+			boneProcess(RQ('withered_rib'),TC('necrotic_bone'),MC('black_dye'))
+			event.recipes.minecraft.stonecutting('5x minecraft:bone',RQ('withered_rib'))
 		}
 		if(Platform.isLoaded('thermal')){//Crystallizer
 			event.custom({"type": "thermal:crystallizer",

--- a/overrides/kubejs/server_scripts/mods/reliquary.js
+++ b/overrides/kubejs/server_scripts/mods/reliquary.js
@@ -3,5 +3,34 @@ if(Platform.isLoaded("reliquary")) {
 		event.forEachRecipe({id: /alkahestry/}, recipe => {
 			recipe.id(recipe.getId() + '_manual_only')
 		})
+
+		//Vials contain fluid
+		let vialAmount = 240 //Should be mod 3, < 250
+		let container = RQ('empty_potion_vial')
+		let vials = ['glowing_water','angelheart_vial','aphrodite_potion','fertile_potion']
+		let ingredients = [
+			[Fluid.of(MC('water'),vialAmount),MC('glowstone_dust'),MC('nether_wart'),MC('gunpowder')],
+			[Fluid.of(MC('milk'),vialAmount),RQ('infernal_claw'),RQ('fertile_essence',2)],
+			[Fluid.of(MC('water'),vialAmount),RQ('fertile_essence'),MC('red_dye'),MC('cocoa_beans')],
+			[Fluid.of(MC('water'),vialAmount),RQ('slime_pearl'),RQ('catalyzing_gland'),RQ('rib_bone')]
+		]
+		for (let i = 0; i < vials.length; i++) {
+			var potion = Fluid.of(KJ(vials[i]),vialAmount)
+			event.recipes.createFilling(RQ(vials[i]), [container, potion])
+			event.recipes.createEmptying([container, potion], RQ(vials[i]))
+			event.recipes.createMixing(potion, ingredients[i])
+		}
+
+		//Recipes
+		event.recipes.createFilling(RQ('glowing_bread'),[F('#bread'),Fluid.of(KJ('fertile_potion'),vialAmount/3)])
+		event.recipes.createMixing(RQ('holy_hand_grenade',4),[Fluid.of(KJ('glowing_water'),vialAmount),MC('gold_nugget'),MC('tnt'),RQ('catalyzing_gland')])
+
+		event.recipes.createFilling(RQ('phoenix_down'), [RQ('angelic_feather'),Fluid.of(KJ('angelheart_vial'),vialAmount*3)])
+
+		event.recipes.createFilling(RQ('fertile_essence'),[MC('green_dye'),Fluid.of(KJ('fertile_potion'),vialAmount)])
+		event.recipes.createEmptying([MC('green_dye'),Fluid.of(KJ('fertile_potion'),vialAmount)], RQ('fertile_essence'))
+		event.recipes.createMixing(RQ('witherless_rose'),[MC('rose_bush'),Fluid.of(KJ('fertile_potion'),vialAmount*4),F('#nether_stars',4)])
+		event.recipes.createFilling(RQ('fertile_lily_pad'),[MC('lily_pad'),Fluid.of(KJ('fertile_potion'),vialAmount*3)])
+
 	})
 }

--- a/overrides/kubejs/server_scripts/mods/reliquary.js
+++ b/overrides/kubejs/server_scripts/mods/reliquary.js
@@ -32,6 +32,12 @@ if(Platform.isLoaded("reliquary")) {
 		event.recipes.createMixing(RQ('witherless_rose'),[MC('rose_bush'),Fluid.of(KJ('fertile_potion'),vialAmount*4),F('#nether_stars',4)])
 		event.recipes.createFilling(RQ('fertile_lily_pad'),[MC('lily_pad'),Fluid.of(KJ('fertile_potion'),vialAmount*3)])
 		event.recipes.createMixing(RQ('angelic_feather'),[F('#feathers'),RQ('nebulous_heart'),RQ('bat_wing'),Fluid.of(KJ('fertile_potion'),vialAmount)])
+		if (Platform.isLoaded("sliceanddice")){
+			event.recipes.create.mixing(
+				[Fluid.of('minecraft:water',216),Fluid.of('kubejs:fertile_potion',24)],
+				[Fluid.of('sliceanddice:fertilizer',240)]
+			)
+		}
 
 		//Mob drops
 		event.remove({id:"reliquary:uncrafting/bone"})

--- a/overrides/kubejs/server_scripts/mods/reliquary.js
+++ b/overrides/kubejs/server_scripts/mods/reliquary.js
@@ -43,6 +43,13 @@ if(Platform.isLoaded("reliquary")) {
 				Item.of(dye).withCount(5).withChance(0.40),
 				Item.of(MC('bone_meal',15)).withChance(0.40)
 			], rib)
+			if(Platform.isLoaded('thermal')){
+				event.recipes.thermal.pulverizer([
+					MC('bone_meal',15),
+					Item.of(dye).withCount(5).withChance(0.40),
+					Item.of(MC('bone_meal',15)).withChance(0.40)
+				], rib)
+			}
 		}
 		boneProcess(RQ('rib_bone'), MC('bone'), MC('white_dye'))
 		event.recipes.createMilling([MC('gunpowder',8)],RQ('catalyzing_gland'))
@@ -121,6 +128,12 @@ if(Platform.isLoaded("reliquary")) {
 					"count":6
 				}]
 			})
+			event.recipes.thermal.pulverizer([MC('gunpowder',8)],RQ('catalyzing_gland'))
+			event.recipes.thermal.pulverizer([MC('gunpowder',12)],RQ('eye_of_the_storm'))
+			event.recipes.thermal.pulverizer([MC('snowball',6)],RQ('frozen_core'))
+			event.recipes.thermal.pulverizer(['4x ae2:ender_dust'],RQ('nebulous_heart'))
+			event.recipes.thermal.pulverizer([MC('prismarine_shard',6)],RQ('guardian_spike'))
+			event.recipes.thermal.pulverizer([MC('black_dye',15),MC('gray_dye')],RQ('squid_beak'))
 		}
 	})
 }

--- a/overrides/kubejs/startup_scripts/mods/reliquary.js
+++ b/overrides/kubejs/startup_scripts/mods/reliquary.js
@@ -1,8 +1,8 @@
 if(Platform.isLoaded("reliquary")){
     onEvent('fluid.registry', event => {
-        event.create('glowing_water').thinTexture(0x436ee6)//.bucketColor(0x00FFFF)
-        event.create('angelheart_vial').thinTexture(0xcc6d3d)
-        event.create('aphrodite_potion').thinTexture(0xb5b138)
-        event.create('fertile_potion').thinTexture(0x85d842)
+        event.create('glowing_water').thinTexture(0x436ee6).rarity("common")
+        event.create('angelheart_vial').thinTexture(0xcc6d3d).rarity("common")
+        event.create('aphrodite_potion').thinTexture(0xb5b138).rarity("common").displayName("Aphrodite's Serum")
+        event.create('fertile_potion').thinTexture(0x85d842).rarity("common")
     })
 }

--- a/overrides/kubejs/startup_scripts/mods/reliquary.js
+++ b/overrides/kubejs/startup_scripts/mods/reliquary.js
@@ -1,0 +1,8 @@
+if(Platform.isLoaded("reliquary")){
+    onEvent('fluid.registry', event => {
+        event.create('glowing_water').thinTexture(0x436ee6)//.bucketColor(0x00FFFF)
+        event.create('angelheart_vial').thinTexture(0xcc6d3d)
+        event.create('aphrodite_potion').thinTexture(0xb5b138)
+        event.create('fertile_potion').thinTexture(0x85d842)
+    })
+}


### PR DESCRIPTION
**Describe the PR**
This PR does 3 things : 
- Make the potion vials form Reliquary contain fluid (filling/emptying, making the fluid in the mixer, using fluid in other recipes)
- Process mob loot via crushing/melting, with slightly higher yields as an incentive (i.e. 8 gunpowder instead of 6)
- Improve compat with Slice and dice (fertile potion -> fertilizer) and enchantment industries (squid drop -> liquid ink)
