### PR TITLE
Add Trial Chambers to the 1.20 version of CABIN

### DIFF
--- a/kubejs/client_scripts/JEI_potions.js
+++ b/kubejs/client_scripts/JEI_potions.js
@@ -22,6 +22,13 @@ const POTIONS = [ //The order that we create these rei entries in is important!
     ["minecraft:slow_falling", ['long']]
 ];
 
+if (Platform.isLoaded('trials')) {
+    POTIONS.push(["trials:winded", []])
+    POTIONS.push(["trials:infested", []])
+    POTIONS.push(["trials:weaving", []])
+    POTIONS.push(["trials:oozing", []])
+}
+
 //Add Potion fluids to REI
 JEIEvents.add('fluid', event => {
     POTION_BOTTLES.forEach(bottle=>{

--- a/kubejs/data/kubejs/loot_tables/gameplay/trials/ore_loot.json
+++ b/kubejs/data/kubejs/loot_tables/gameplay/trials/ore_loot.json
@@ -1,0 +1,43 @@
+{
+    "type": "minecraft:generic",
+    "pools": [
+      {
+        "rolls": 1,
+        "entries": [
+          {
+            "type": "minecraft:item",
+            "name": "minecraft:raw_copper",
+            "weight": 8,
+            "functions": [{"function": "set_count", "count": {"min": 1, "max": 2}}]
+          },
+          {
+            "type": "minecraft:item",
+            "name": "create:raw_zinc",
+            "weight": 8,
+            "functions": [{"function": "set_count", "count": {"min": 1, "max": 2}}]
+          },
+          {
+            "type": "minecraft:item",
+            "name": "minecraft:raw_iron",
+            "weight": 6,
+            "functions": [{"function": "set_count", "count": {"min": 1, "max": 2}}]
+          },
+          {
+            "type": "minecraft:item",
+            "name": "minecraft:raw_gold",
+            "weight": 6
+          },
+          {
+            "type": "minecraft:item",
+            "name": "thermal:raw_lead",
+            "weight": 4
+          },
+          {
+            "type": "minecraft:item",
+            "name": "thermal:raw_nickel",
+            "weight": 4
+          }
+        ]
+      }
+    ]
+  }

--- a/kubejs/server_scripts/mods/trials.js
+++ b/kubejs/server_scripts/mods/trials.js
@@ -1,0 +1,350 @@
+//Trial Chamber backport
+if (Platform.isLoaded('trials')) {
+    ServerEvents.lowPriorityData(event => {
+        
+        //Make a Trial Processor using IntegratedAPI and Lithostitched
+        //Integrated API's waterlog fix processor is used to fix blocks being waterlogged when the structure generates over water
+        //Lithostitched is used to swap blocks while copying over properties. (without it this processor would be almost 3000 lines long)
+        event.addJson("trials:worldgen/processor_list/generic", {
+            "processors": [
+            {
+                "processor_type": "integrated_api:waterlogging_fix_processor"
+            },
+            {
+                "processor_type": "lithostitched:block_swap",
+                "blocks": {
+                    "minecraft:waxed_copper_block": "kubejs:trial_copper_block",
+                    "minecraft:waxed_cut_copper": "kubejs:trial_cut_copper",
+                    "trials:waxed_chiseled_copper": "kubejs:trial_chiseled_copper",
+                    "trials:waxed_copper_grate": "kubejs:trial_copper_grate",
+                    "minecraft:waxed_cut_copper_stairs": "kubejs:trial_cut_copper_stairs",
+                    "minecraft:waxed_cut_copper_slab": "kubejs:trial_cut_copper_slab",
+                    "minecraft:waxed_oxidized_copper": "kubejs:trial_oxidized_copper_block",
+                    "minecraft:waxed_oxidized_cut_copper": "kubejs:trial_oxidized_cut_copper",
+                    "trials:waxed_chiseled_copper_oxidized": "kubejs:trial_oxidized_chiseled_copper",
+                    "trials:waxed_copper_grate_oxidized": "kubejs:trial_oxidized_copper_grate",
+                    "minecraft:waxed_oxidized_cut_copper_stairs": "kubejs:trial_oxidized_cut_copper_stairs",
+                    "minecraft:waxed_oxidized_cut_copper_slab":"kubejs:trial_oxidized_cut_copper_slab" 
+                }
+            }
+            ]
+        })
+
+        //Replace the food reward in ominous spawners with ore instead
+        event.addJson('trials:loot_tables/gameplay/spawner_special_loot', {
+            "type": "minecraft:generic",
+            "pools": [
+              {
+                "rolls": 1,
+                "entries": [
+                  {
+                    "type": "minecraft:item",
+                    "name": "trials:trial_key_ominous",
+                    "weight": 1
+                  },
+                  {
+                    "type": "minecraft:loot_table",
+                    "name": "kubejs:gameplay/trials/ore_loot",
+                    "weight": 1
+                  }
+                ]
+              }
+            ]
+          })
+
+
+        //First we'll set the array as the default loot tables. This makes it more clear what exactly we're changing about them.
+        //If LootJS didn't suck in this version, then we could have used that instead
+        const normalVaultLoot = [
+            {
+                "type": "minecraft:item",
+                "name": "minecraft:emerald",
+                "weight": 15,
+                "functions": [
+                    { "function": "set_count", "count": { "min": 2, "max": 6 } }
+                ]
+            },
+            {
+                "type": "minecraft:item",
+                "name": "minecraft:golden_carrot",
+                "weight": 12,
+                "functions": [
+                    { "function": "set_count", "count": { "min": 2, "max": 4 } }
+                ]
+            },
+            {
+                "type": "minecraft:item",
+                "name": "minecraft:iron_ingot",
+                "weight": 12,
+                "functions": [
+                    { "function": "set_count", "count": { "min": 2, "max": 4 } }
+                ]
+            },
+            {
+                "type": "minecraft:item",
+                "name": "trials:breeze_rod",
+                "weight": 8,
+                "functions": [
+                    { "function": "set_count", "count": { "min": 2, "max": 6 } }
+                ]
+            },
+            {
+                "type": "minecraft:item",
+                "name": "minecraft:ender_pearl",
+                "weight": 8,
+                "functions": [
+                    { "function": "set_count", "count": { "min": 1, "max": 2 } }
+                ]
+            },
+            {
+                "type": "minecraft:item",
+                "name": "trials:ominous_bottle",
+                "weight": 8
+            },
+            {
+                "type": "minecraft:item",
+                "name": "minecraft:arrow",
+                "weight": 8,
+                "functions": [
+                    { "function": "set_count", "count": { "min": 6, "max": 12 } }
+                ]
+            },
+            {
+                "type": "minecraft:item",
+                "name": "minecraft:golden_apple",
+                "weight": 8
+            },
+            {
+                "type": "minecraft:item",
+                "name": "minecraft:book",
+                "weight": 6,
+                "functions": [
+                    {
+                        "function": "minecraft:enchant_randomly",
+                        "enchantments": ["minecraft:mending", "minecraft:riptide", "minecraft:loyalty", "minecraft:channeling", "minecraft:impaling"]
+                    }
+                ]
+            },
+            {
+                "type": "minecraft:item",
+                "name": "minecraft:book",
+                "weight": 6,
+                "functions": [
+                    {
+                        "function": "minecraft:enchant_randomly",
+                        "enchantments": ["minecraft:sharpness", "minecraft:smite", "minecraft:efficiency", "minecraft:fortune", "minecraft:silk_touch", "minecraft:feather_falling"]
+                    }
+                ]
+            },
+            {
+                "type": "minecraft:item",
+                "name": "minecraft:diamond",
+                "weight": 4,
+                "functions": [
+                    { "function": "set_count", "count": { "min": 1, "max": 2 } }
+                ]
+            },
+            {
+                "type": "minecraft:loot_table",
+                "name": "trials:gameplay/iron_armor",
+                "weight": 4
+            },
+            {
+                "type": "minecraft:item",
+                "name": "trials:bolt_template",
+                "weight": 2
+            },
+            {
+                "type": "minecraft:item",
+                "name": "trials:music_disc_precipice",
+                "weight": 2
+            }
+        ]
+
+        const ominousVaultLoot = [
+            {
+                "type": "minecraft:item",
+                "name": "minecraft:emerald",
+                "weight": 15,
+                "functions": [
+                    { "function": "set_count", "count": { "min": 2, "max": 6 } }
+                ]
+            },
+            {
+                "type": "minecraft:item",
+                "name": "minecraft:golden_carrot",
+                "weight": 12,
+                "functions": [
+                    { "function": "set_count", "count": { "min": 2, "max": 4 } }
+                ]
+            },
+            {
+                "type": "minecraft:item",
+                "name": "minecraft:iron_ingot",
+                "weight": 12,
+                "functions": [
+                    { "function": "set_count", "count": { "min": 2, "max": 4 } }
+                ]
+            },
+            {
+                "type": "minecraft:item",
+                "name": "minecraft:ender_pearl",
+                "weight": 8,
+                "functions": [
+                    { "function": "set_count", "count": { "min": 1, "max": 2 } }
+                ]
+            },
+            {
+                "type": "minecraft:item",
+                "name": "minecraft:golden_apple",
+                "weight": 8
+            },
+            {
+                "type": "minecraft:item",
+                "name": "minecraft:book",
+                "weight": 6,
+                "functions": [
+                    { "function": "minecraft:enchant_randomly", "enchantments": ["trials:density", "trials:breach", "trials:wind_burst"] }
+                ]
+            },
+            {
+                "type": "minecraft:item",
+                "name": "trials:ominous_bottle",
+                "weight": 6
+            },
+            {
+                "type": "minecraft:item",
+                "name": "minecraft:emerald_block",
+                "weight": 6
+            },
+            {
+                "type": "minecraft:item",
+                "name": "minecraft:iron_block",
+                "weight": 4
+            },
+            {
+                "type": "minecraft:item",
+                "name": "minecraft:diamond",
+                "weight": 4,
+                "functions": [
+                    { "function": "set_count", "count": { "min": 1, "max": 2 } }
+                ]
+            },
+            {
+                "type": "minecraft:loot_table",
+                "name": "trials:gameplay/diamond_armor",
+                "weight": 4
+            },
+            {
+                "type": "minecraft:item",
+                "name": "trials:flow_template",
+                "weight": 2
+            },
+            {
+                "type": "minecraft:item",
+                "name": "trials:music_disc_creator",
+                "weight": 2
+            },
+            {
+                "type": "minecraft:item",
+                "name": "minecraft:diamond_block",
+                "weight": 1
+            }
+        ]
+
+        
+
+        //Now we add our own loot
+
+        //Gives way too many emeralds
+        normalVaultLoot.splice(normalVaultLoot.findIndex(loot=>loot.name=='minecraft:emerald'),1)
+        normalVaultLoot.push({
+            "type": "minecraft:item",
+            "name": "minecraft:emerald",
+            "weight": 5,
+            "functions": [{ "function": "set_count", "count": { "min": 2, "max": 6 } }]
+        })
+        normalVaultLoot.push({
+            "type": "minecraft:item",
+            "name": "thermal:cinnabar",
+            "weight": 3,
+            "functions": [{ "function": "set_count", "count": { "min": 2, "max": 6 } }]
+        })
+
+        normalVaultLoot.push({
+            "type": "minecraft:item",
+            "name": "create:andesite_alloy_block",
+            "weight": 12,
+            "functions": [{ "function": "set_count", "count": { "min": 1, "max": 2 } }]
+        })
+        normalVaultLoot.push({
+            "type": "minecraft:item",
+            "name": "create:brass_ingot",
+            "weight": 4,
+            "functions": [{ "function": "set_count", "count": { "min": 2, "max": 6 } }]
+        })
+
+
+
+        //Gives way too many emeralds
+        ominousVaultLoot.splice(normalVaultLoot.findIndex(loot=>loot.name=='minecraft:emerald'),1)
+        ominousVaultLoot.push({
+            "type": "minecraft:item",
+            "name": "minecraft:emerald",
+            "weight": 3,
+            "functions": [{ "function": "set_count", "count": { "min": 2, "max": 6 } }]
+        })
+        ominousVaultLoot.push({
+            "type": "minecraft:item",
+            "name": "thermal:ruby",
+            "weight": 3,
+            "functions": [{ "function": "set_count", "count": { "min": 1, "max": 2 } }]
+        })
+        ominousVaultLoot.push({
+            "type": "minecraft:item",
+            "name": "thermal:sapphire",
+            "weight": 3,
+            "functions": [{ "function": "set_count", "count": { "min": 1, "max": 2 } }]
+        })
+        ominousVaultLoot.push({
+            "type": "minecraft:item",
+            "name": "thermal:cinnabar",
+            "weight": 6,
+            "functions": [{ "function": "set_count", "count": { "min": 2, "max": 6 } }]
+        })
+
+        ominousVaultLoot.push({
+            "type": "minecraft:item",
+            "name": "create:brass_ingot",
+            "weight": 12,
+            "functions": [{ "function": "set_count", "count": { "min": 2, "max": 4 } }]
+        })
+        ominousVaultLoot.push({
+            "type": "minecraft:item",
+            "name": "create:brass_block",
+            "weight": 4,
+        })
+
+
+
+        event.addJson('trials:loot_tables/gameplay/vault_loot', {
+            "type": "minecraft:generic",
+            "pools": [
+                {
+                    "rolls": 1,
+                    "entries": normalVaultLoot
+                }
+            ]
+        })
+
+        event.addJson('trials:loot_tables/gameplay/vault_special_loot', {
+            "type": "minecraft:generic",
+            "pools": [
+                {
+                    "rolls": 1,
+                    "entries": ominousVaultLoot
+                }
+            ]
+        })
+    })
+}

--- a/kubejs/startup_scripts/generate.js
+++ b/kubejs/startup_scripts/generate.js
@@ -116,6 +116,20 @@ StartupEvents.registry('item', event => {
 
 StartupEvents.registry("block", event => {
 
+	event.create('trial_copper_block').model('minecraft:block/copper_block').soundType('metal').tagBlock("mineable/pickaxe").tagBlock("needs_stone_tool").requiresTool(true).hardness(3.0).resistance(6.0).displayName("Illusionary Block of Copper")
+	event.create('trial_cut_copper').model('minecraft:block/cut_copper').soundType('metal').tagBlock("mineable/pickaxe").tagBlock("needs_stone_tool").requiresTool(true).hardness(3.0).resistance(6.0).displayName("Illusionary Cut Copper")
+	event.create('trial_chiseled_copper').model('trials:block/chiseled_copper').soundType('metal').tagBlock("mineable/pickaxe").tagBlock("needs_stone_tool").requiresTool(true).hardness(3.0).resistance(6.0).displayName("Illusionary Chiseled Copper")
+	event.create('trial_copper_grate').model('trials:block/copper_grate').soundType('metal').tagBlock("mineable/pickaxe").tagBlock("needs_stone_tool").requiresTool(true).hardness(3.0).resistance(6.0).displayName("Illusionary Copper Grate").notSolid().waterlogged()
+	event.create('trial_cut_copper_stairs', "stairs").textureAll('minecraft:block/cut_copper').soundType('metal').tagBlock("mineable/pickaxe").tagBlock("needs_stone_tool").requiresTool(true).hardness(3.0).resistance(6.0).displayName("Illusionary Cut Copper Stairs")
+	event.create('trial_cut_copper_slab', "slab").textureAll('minecraft:block/cut_copper').soundType('metal').tagBlock("mineable/pickaxe").tagBlock("needs_stone_tool").requiresTool(true).hardness(3.0).resistance(6.0).displayName("Illusionary Cut Copper Slab")
+	
+	event.create('trial_oxidized_copper_block').model('minecraft:block/oxidized_copper').soundType('metal').tagBlock("mineable/pickaxe").tagBlock("needs_stone_tool").requiresTool(true).hardness(3.0).resistance(6.0).displayName("Illusionary Oxidized Block of Copper")
+	event.create('trial_oxidized_cut_copper').model('minecraft:block/oxidized_cut_copper').soundType('metal').tagBlock("mineable/pickaxe").tagBlock("needs_stone_tool").requiresTool(true).hardness(3.0).resistance(6.0).displayName("Illusionary Oxidized Cut Copper")
+	event.create('trial_oxidized_chiseled_copper').model('trials:block/chiseled_copper_oxidized').soundType('metal').tagBlock("mineable/pickaxe").tagBlock("needs_stone_tool").requiresTool(true).hardness(3.0).resistance(6.0).displayName("Illusionary Oxidized Chiseled Copper")
+	event.create('trial_oxidized_copper_grate').model('trials:block/copper_grate_oxidized').soundType('metal').tagBlock("mineable/pickaxe").tagBlock("needs_stone_tool").requiresTool(true).hardness(3.0).resistance(6.0).displayName("Illusionary Oxidized Copper Grate").notSolid().waterlogged()
+	event.create('trial_oxidized_cut_copper_stairs', "stairs").textureAll('minecraft:block/oxidized_cut_copper').soundType('metal').tagBlock("mineable/pickaxe").tagBlock("needs_stone_tool").requiresTool(true).hardness(3.0).resistance(6.0).displayName("Illusionary Oxidized Cut Copper Stairs")
+	event.create('trial_oxidized_cut_copper_slab', "slab").textureAll('minecraft:block/oxidized_cut_copper').soundType('metal').tagBlock("mineable/pickaxe").tagBlock("needs_stone_tool").requiresTool(true).hardness(3.0).resistance(6.0).displayName("Illusionary Oxidized Cut Copper Slab")
+
 	event.create('enderium_casing').model('cabin:block/enderium_casing').soundType('metal').tagBlock("mineable/pickaxe").tagBlock("create:wrench_pickup").requiresTool(true).hardness(4.0).displayName('Ender Casing')
 	event.create('zinc_casing').textureAll('cabin:block/zinc_casing').soundType('metal').tagBlock("mineable/pickaxe").tagBlock("create:wrench_pickup").requiresTool(true).hardness(3.0).displayName('Zinc Casing')
 	event.create('invar_casing').textureAll('cabin:block/invar_casing').soundType('metal').tagBlock("mineable/pickaxe").tagBlock("create:wrench_pickup").requiresTool(true).hardness(3.0).displayName('Invar Casing')

--- a/kubejs/startup_scripts/mods/trials.js
+++ b/kubejs/startup_scripts/mods/trials.js
@@ -1,0 +1,9 @@
+if (Platform.isLoaded('trials')) {
+    MoreJSEvents.registerPotionBrewing((event) => {
+        //Potion recipes are not shown in jei by default for some reason
+        event.addPotionBrewing("trials:breeze_rod", "minecraft:awkward", "trials:winded");
+        event.addPotionBrewing("minecraft:stone", "minecraft:awkward", "trials:infested");
+        event.addPotionBrewing("minecraft:cobweb", "minecraft:awkward", "trials:weaving");
+        event.addPotionBrewing("minecraft:slime_block", "minecraft:awkward", "trials:oozing");
+    })
+}

--- a/manifest.json
+++ b/manifest.json
@@ -815,6 +815,16 @@
          "fileID": 6095052,
          "projectID": 815548,
          "required": true
+      },
+      {
+         "fileID": 6183392,
+         "projectID": 936015,
+         "required": true
+      },
+      {
+         "fileID": 6008720,
+         "projectID": 1012027,
+         "required": true
       }
    ],
    "manifestType": "minecraftModpack",

--- a/manifest.json
+++ b/manifest.json
@@ -825,6 +825,11 @@
          "fileID": 6008720,
          "projectID": 1012027,
          "required": true
+      },
+      {
+         "fileID": 4931972,
+         "projectID": 847583,
+         "required": true
       }
    ],
    "manifestType": "minecraftModpack",

--- a/resourcepacks/CABIN/assets/cabin/jade/target_modifier/kubejs/trial_chiseled_copper.json
+++ b/resourcepacks/CABIN/assets/cabin/jade/target_modifier/kubejs/trial_chiseled_copper.json
@@ -1,0 +1,9 @@
+{
+	"type": "replace",
+	"target": {
+		"block": "kubejs:trial_chiseled_copper"
+	},
+	"with": {
+		"block": "trials:waxed_chiseled_copper"
+	}
+}

--- a/resourcepacks/CABIN/assets/cabin/jade/target_modifier/kubejs/trial_copper_block.json
+++ b/resourcepacks/CABIN/assets/cabin/jade/target_modifier/kubejs/trial_copper_block.json
@@ -1,0 +1,9 @@
+{
+	"type": "replace",
+	"target": {
+		"block": "kubejs:trial_copper_block"
+	},
+	"with": {
+		"block": "minecraft:waxed_copper_block"
+	}
+}

--- a/resourcepacks/CABIN/assets/cabin/jade/target_modifier/kubejs/trial_copper_grate.json
+++ b/resourcepacks/CABIN/assets/cabin/jade/target_modifier/kubejs/trial_copper_grate.json
@@ -1,0 +1,9 @@
+{
+	"type": "replace",
+	"target": {
+		"block": "kubejs:trial_copper_grate"
+	},
+	"with": {
+		"block": "trials:waxed_copper_grate"
+	}
+}

--- a/resourcepacks/CABIN/assets/cabin/jade/target_modifier/kubejs/trial_cut_copper.json
+++ b/resourcepacks/CABIN/assets/cabin/jade/target_modifier/kubejs/trial_cut_copper.json
@@ -1,0 +1,9 @@
+{
+	"type": "replace",
+	"target": {
+		"block": "kubejs:trial_cut_copper"
+	},
+	"with": {
+		"block": "minecraft:waxed_cut_copper"
+	}
+}

--- a/resourcepacks/CABIN/assets/cabin/jade/target_modifier/kubejs/trial_cut_copper_slab.json
+++ b/resourcepacks/CABIN/assets/cabin/jade/target_modifier/kubejs/trial_cut_copper_slab.json
@@ -1,0 +1,9 @@
+{
+	"type": "replace",
+	"target": {
+		"block": "kubejs:trial_cut_copper_slab"
+	},
+	"with": {
+		"block": "minecraft:waxed_cut_copper_slab"
+	}
+}

--- a/resourcepacks/CABIN/assets/cabin/jade/target_modifier/kubejs/trial_cut_copper_stairs.json
+++ b/resourcepacks/CABIN/assets/cabin/jade/target_modifier/kubejs/trial_cut_copper_stairs.json
@@ -1,0 +1,9 @@
+{
+	"type": "replace",
+	"target": {
+		"block": "kubejs:trial_cut_copper_stairs"
+	},
+	"with": {
+		"block": "minecraft:waxed_cut_copper_stairs"
+	}
+}

--- a/resourcepacks/CABIN/assets/cabin/jade/target_modifier/kubejs/trial_oxidized_chiseled_copper.json
+++ b/resourcepacks/CABIN/assets/cabin/jade/target_modifier/kubejs/trial_oxidized_chiseled_copper.json
@@ -1,0 +1,9 @@
+{
+	"type": "replace",
+	"target": {
+		"block": "kubejs:trial_oxidized_chiseled_copper"
+	},
+	"with": {
+		"block": "trials:waxed_chiseled_copper_oxidized"
+	}
+}

--- a/resourcepacks/CABIN/assets/cabin/jade/target_modifier/kubejs/trial_oxidized_copper_block.json
+++ b/resourcepacks/CABIN/assets/cabin/jade/target_modifier/kubejs/trial_oxidized_copper_block.json
@@ -1,0 +1,9 @@
+{
+	"type": "replace",
+	"target": {
+		"block": "kubejs:trial_oxidized_copper_block"
+	},
+	"with": {
+		"block": "minecraft:waxed_oxidized_copper"
+	}
+}

--- a/resourcepacks/CABIN/assets/cabin/jade/target_modifier/kubejs/trial_oxidized_copper_grate.json
+++ b/resourcepacks/CABIN/assets/cabin/jade/target_modifier/kubejs/trial_oxidized_copper_grate.json
@@ -1,0 +1,9 @@
+{
+	"type": "replace",
+	"target": {
+		"block": "kubejs:trial_oxidized_copper_grate"
+	},
+	"with": {
+		"block": "trials:waxed_copper_grate_oxidized"
+	}
+}

--- a/resourcepacks/CABIN/assets/cabin/jade/target_modifier/kubejs/trial_oxidized_cut_copper.json
+++ b/resourcepacks/CABIN/assets/cabin/jade/target_modifier/kubejs/trial_oxidized_cut_copper.json
@@ -1,0 +1,9 @@
+{
+	"type": "replace",
+	"target": {
+		"block": "kubejs:trial_oxidized_cut_copper"
+	},
+	"with": {
+		"block": "minecraft:waxed_oxidized_cut_copper"
+	}
+}

--- a/resourcepacks/CABIN/assets/cabin/jade/target_modifier/kubejs/trial_oxidized_cut_copper_slab.json
+++ b/resourcepacks/CABIN/assets/cabin/jade/target_modifier/kubejs/trial_oxidized_cut_copper_slab.json
@@ -1,0 +1,9 @@
+{
+	"type": "replace",
+	"target": {
+		"block": "kubejs:trial_oxidized_cut_copper_slab"
+	},
+	"with": {
+		"block": "minecraft:waxed_oxidized_cut_copper_slab"
+	}
+}

--- a/resourcepacks/CABIN/assets/cabin/jade/target_modifier/kubejs/trial_oxidized_cut_copper_stairs.json
+++ b/resourcepacks/CABIN/assets/cabin/jade/target_modifier/kubejs/trial_oxidized_cut_copper_stairs.json
@@ -1,0 +1,9 @@
+{
+	"type": "replace",
+	"target": {
+		"block": "kubejs:trial_oxidized_cut_copper_stairs"
+	},
+	"with": {
+		"block": "minecraft:waxed_oxidized_cut_copper_stairs"
+	}
+}


### PR DESCRIPTION
Adds Lithostitched and Trials Chambers to the pack.
Tweaks the loot tables a bit to give items that are more useful for pack progression.
Makes the copper blocks in trial chambers unusable for melting down into copper