### PR TITLE
Only track the CABIN resource packs that are directly in this repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,9 @@
 !/config-overrides
 !/kubejs
 !/defaultconfigs
-!/resourcepacks/CABIN*
+!/resourcepacks/
+/resourcepacks/*
+!/resourcepacks/CABIN*/
 !/.gitignore
 !/.gitattributes
 !/manifest.json

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 !/config-overrides
 !/kubejs
 !/defaultconfigs
-!/resourcepacks
+!/resourcepacks/CABIN*
 !/.gitignore
 !/.gitattributes
 !/manifest.json


### PR DESCRIPTION
Signed-off-by: Becquerel <46350316+TheDogOfChaos@users.noreply.github.com>

**Describe the PR**
updated the .gitignore so contributors dont accidentally commit the resource packs that are downloaded when importing builds of this pack