### PR TITLE
adjust strainer_base_filter.json to reduce z-fighting with waterlogged blocks

### DIFF
--- a/ldlib/assets/mbd2/models/block/strainer_base_filter.json
+++ b/ldlib/assets/mbd2/models/block/strainer_base_filter.json
@@ -77,8 +77,9 @@
 		},
 		{
 			"name": "Strainer_N",
-			"from": [1, 16, 0],
+			"from": [1, 16, 0.25],
 			"to": [15, 30, 1],
+			"rotation": {"angle": 0, "axis": "y", "origin": [0, 0, 0.25]},
 			"faces": {
 				"north": {"uv": [0, 0, 16, 16], "texture": "#2"},
 				"east": {"uv": [0, 1, 16, 2], "texture": "#-1"},
@@ -91,7 +92,7 @@
 		{
 			"name": "Strainer_S",
 			"from": [1, 16, 15],
-			"to": [15, 30, 16],
+			"to": [15, 30, 15.75],
 			"faces": {
 				"north": {"uv": [0, 0, 16, 16], "texture": "#2"},
 				"east": {"uv": [0, 0, 16, 16], "texture": "#-1"},
@@ -104,7 +105,7 @@
 		{
 			"name": "Strainer_E",
 			"from": [15, 16, 1],
-			"to": [16, 30, 15],
+			"to": [15.75, 30, 15],
 			"faces": {
 				"north": {"uv": [0, 0, 16, 16], "texture": "#-1"},
 				"east": {"uv": [0, 0, 16, 16], "texture": "#2"},
@@ -116,8 +117,9 @@
 		},
 		{
 			"name": "Strainer_W",
-			"from": [0, 16, 1],
+			"from": [0.25, 16, 1],
 			"to": [1, 30, 15],
+			"rotation": {"angle": 0, "axis": "y", "origin": [0.25, 0, 0]},
 			"faces": {
 				"north": {"uv": [0, 0, 16, 16], "texture": "#-1"},
 				"east": {"uv": [0, 0, 16, 16], "texture": "#2"},

--- a/resourcepacks/CABIN/assets/waterstrainer/models/block/strainer_base_filter.json
+++ b/resourcepacks/CABIN/assets/waterstrainer/models/block/strainer_base_filter.json
@@ -77,8 +77,9 @@
 		},
 		{
 			"name": "Strainer_N",
-			"from": [1, 16, 0],
+			"from": [1, 16, 0.25],
 			"to": [15, 30, 1],
+			"rotation": {"angle": 0, "axis": "y", "origin": [0, 0, 0.25]},
 			"faces": {
 				"north": {"uv": [0, 0, 16, 16], "texture": "#2"},
 				"east": {"uv": [0, 1, 16, 2], "texture": "#-1"},
@@ -91,7 +92,7 @@
 		{
 			"name": "Strainer_S",
 			"from": [1, 16, 15],
-			"to": [15, 30, 16],
+			"to": [15, 30, 15.75],
 			"faces": {
 				"north": {"uv": [0, 0, 16, 16], "texture": "#2"},
 				"east": {"uv": [0, 0, 16, 16], "texture": "#-1"},
@@ -104,7 +105,7 @@
 		{
 			"name": "Strainer_E",
 			"from": [15, 16, 1],
-			"to": [16, 30, 15],
+			"to": [15.75, 30, 15],
 			"faces": {
 				"north": {"uv": [0, 0, 16, 16], "texture": "#-1"},
 				"east": {"uv": [0, 0, 16, 16], "texture": "#2"},
@@ -116,8 +117,9 @@
 		},
 		{
 			"name": "Strainer_W",
-			"from": [0, 16, 1],
+			"from": [0.25, 16, 1],
 			"to": [1, 30, 15],
+			"rotation": {"angle": 0, "axis": "y", "origin": [0.25, 0, 0]},
 			"faces": {
 				"north": {"uv": [0, 0, 16, 16], "texture": "#-1"},
 				"east": {"uv": [0, 0, 16, 16], "texture": "#2"},


### PR DESCRIPTION
**Describe the PR**
Addresses #201 

I made a small tweak to the sediment strainer model to reduce the Z Fighting when using a waterlogged block 

There's still a little z-fighting in the poles holding up filters, but I wanted to keep my changes minimal. 

I imagine I could scale the poles down a little bit, but that would make the numbers a lot less clean.

**Screenshots**
![image](https://github.com/user-attachments/assets/f89bfa81-847a-4ee2-9af8-9d0b245f2f37)
![image](https://github.com/user-attachments/assets/e11932d8-d64b-40ee-878f-7d598fff646a)


