### PR TITLE
Add Create Central Kitchen to the pack

### DIFF
--- a/config/create_central_kitchen-common.toml
+++ b/config/create_central_kitchen-common.toml
@@ -30,4 +30,8 @@
 	#Basket of Farmers Delight has a 8 ticks transfer cooldown. Disable the cooldown for better automation.
 	#[@cui:RequiresReload:server]
 	disableTransferCooldownForFarmersDelightBasket = true
+	#.
+	#For harvester to function properly, turning on this support will cause the collision shape of Coffee Bush and Tea Bush block to disappear.
+	#[@cui:RequiresReload:server]
+	enableHarvesterSupportForFarmersRespite = true
 

--- a/kubejs/client_scripts/bulkhide.js
+++ b/kubejs/client_scripts/bulkhide.js
@@ -52,7 +52,6 @@ JEIEvents.hideItems(event => {
     event.hide("create:crushed_raw_uranium")
     event.hide("create:sturdy_sheet")
     event.hide("create:unprocessed_obsidian_sheet")
-    event.hide("create_central_kitchen:creative_tab_icon")
 
     event.hide(/^createdeco:.*coin/)
 

--- a/kubejs/client_scripts/mods/create_central_kitchen.js
+++ b/kubejs/client_scripts/mods/create_central_kitchen.js
@@ -1,0 +1,53 @@
+if(Platform.isLoaded("create_central_kitchen")) {
+    ClientEvents.highPriorityAssets(event=>{
+        let emiHide = [
+            "item:create_central_kitchen:creative_tab_icon",
+
+            "item:create_central_kitchen:incomplete_egg_sandwich",
+            "item:create_central_kitchen:incomplete_chicken_sandwich",
+            "item:create_central_kitchen:incomplete_hamburger",
+            "item:create_central_kitchen:incomplete_bacon_sandwich",
+            "item:create_central_kitchen:incomplete_mutton_wrap",
+            "item:create_central_kitchen:incomplete_apple_pie",
+            "item:create_central_kitchen:incomplete_sweet_berry_cheesecake",
+            "item:create_central_kitchen:incomplete_pumpkin_pie",
+            "item:create_central_kitchen:incomplete_cherry_pie",
+            "item:create_central_kitchen:incomplete_truffle_pie",
+            "item:create_central_kitchen:incomplete_mulberry_pie",
+        ];
+
+        if (!Platform.isLoaded("upgrade_aquatic")) emiHide.push("item:create_central_kitchen:mulberry_pie_slice")
+            if (!Platform.isLoaded("peculiars")) {
+                emiHide.push("item:create_central_kitchen:aloe_cake_slice")
+                emiHide.push("item:create_central_kitchen:yucca_cake_slice")
+                emiHide.push("item:create_central_kitchen:passionfruit_cake_slice")
+            }
+        if (!Platform.isLoaded("seasonals")) {
+            emiHide.push("item:create_central_kitchen:pumpkin_cake_slice")
+            emiHide.push("item:create_central_kitchen:sweet_berry_cake_slice")
+        }
+        if (!Platform.isLoaded("createaddition")) {
+            emiHide.push("item:create_central_kitchen:chocolate_cake_slice")
+            emiHide.push("item:create_central_kitchen:honey_cake_slice")
+        }
+
+        let json = {
+            removed: emiHide
+        }
+        event.add("emi:index/stacks/create_central_kitchen_removed_stacks", json)
+        
+        //Hide CABIN's fern deploying recipes from EMI since cck has an automated cuting tab.
+        let hiddenRecipes = [
+            "jei:/kubejs/deploying/earth_slime_fern_leaf_using_deployer",
+            "jei:/kubejs/deploying/sky_slime_fern_leaf_using_deployer",
+            "jei:/kubejs/deploying/ender_slime_fern_leaf_using_deployer"
+        ]
+
+        json = {
+            filters: hiddenRecipes.map(recipe=>{return {id: recipe}})
+        }
+
+        event.add("emi:recipe/filters/create_central_kitchen_hidden_recipes", json)
+        
+    })
+}

--- a/kubejs/server_scripts/mods/create_central_kitchen.js
+++ b/kubejs/server_scripts/mods/create_central_kitchen.js
@@ -3,5 +3,36 @@ if(Platform.isLoaded("create_central_kitchen")) {
         // fix cooking guide recipe since sturdy sheets are removed in CABIN
         event.remove({ id: "create_central_kitchen:crafting/cooking_guide" })
         event.shapeless("create_central_kitchen:cooking_guide", ["create:schedule", "farmersdelight:canvas"])
+
+        //Some sequenced assembly recipes don't exist for some reason
+        let transitional = "create_central_kitchen:incomplete_mutton_wrap"
+        event.recipes.create.sequenced_assembly([
+            "farmersdelight:mutton_wrap",
+        ], "#forge:bread", [
+            event.recipes.create.deploying(transitional, [transitional, "#forge:cooked_mutton"]),
+            event.recipes.create.deploying(transitional, [transitional, "#forge:crops/cabbage"]),
+            event.recipes.create.deploying(transitional, [transitional, "#forge:crops/onion"])
+        ]).transitionalItem(transitional)
+            .loops(1)
+            .id("kubejs:mutton_wrap")
+
+        transitional = "create_central_kitchen:incomplete_hamburger"
+        event.recipes.create.sequenced_assembly([
+            "farmersdelight:hamburger",
+        ], "#forge:bread", [
+            event.recipes.create.deploying(transitional, [transitional, "farmersdelight:beef_patty"]),
+            event.recipes.create.deploying(transitional, [transitional, "#forge:crops/cabbage"]),
+            event.recipes.create.deploying(transitional, [transitional, "#forge:crops/tomato"]),
+            event.recipes.create.deploying(transitional, [transitional, "#forge:crops/onion"])
+        ]).transitionalItem(transitional)
+            .loops(1)
+            .id("kubejs:hamburger")
+    })
+
+    ServerEvents.tags("item", event => {
+        //Create central kitchen somes ends up removing automatic shapeless recipes while providing no alternatives.
+        //This is mainly an issue with bowl recipes
+        event.get("create:ignored_in_automatic_shapeless")
+            .remove("minecraft:bowl")
     })
 }

--- a/kubejs/server_scripts/recipes/chapters.js
+++ b/kubejs/server_scripts/recipes/chapters.js
@@ -663,8 +663,8 @@ ServerEvents.recipes(event => {
             "ingredients": [{ "item": fern }],
             "tool": { "tag": "forge:tools/knives" },
             "result": [Item.of(leaf, 2)]
-        }).id(`kjs:cutting/${type}_slime_fern_leaf`)
-        event.custom(ifiniDeploying(event, Item.of(leaf, 2), fern, "#forge:tools/knives"))
+        }).id(`kubejs:cutting/${type}_slime_fern_leaf`)
+        event.custom(ifiniDeploying(event, Item.of(leaf, 2), fern, "#forge:tools/knives")).id(`kubejs:deploying/${type}_slime_fern_leaf_using_deployer`)
         event.custom({
             "type": "occultism:spirit_fire",
             "ingredient": { "item": leaf },

--- a/manifest.json
+++ b/manifest.json
@@ -790,6 +790,11 @@
          "fileID": 5107131,
          "projectID": 961856,
          "required": true
+      },
+      {
+         "fileID": 6353581,
+         "projectID": 820977,
+         "required": true
       }
    ],
    "manifestType": "minecraftModpack",


### PR DESCRIPTION
Hides unused CCK items when the mods they're for aren't installed
Hides the kubejs cutting board deploying recipes so that there aren't duplicate recipes shown in EMI.
Adds sequenced assembly recipes for hamburgers and mutton wraps since CCK seems to have forgotten those.
Allows for bowls in automatic shapeless mixing since CCK doesn't provide a way to automatically craft every bowl recipe.