### PR TITLE
Optimization mods

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -322,6 +322,36 @@
          "required": true
       },
       {
+         "fileID": 6321543,
+         "projectID": 1091339,
+         "required": true
+      },
+      {
+         "fileID": 4917082,
+         "projectID": 840788,
+         "required": true
+      },
+      {
+         "fileID": 6312293,
+         "projectID": 686911,
+         "required": true
+      },
+      {
+         "fileID": 6355861,
+         "projectID": 448233,
+         "required": true
+      },
+      {
+         "fileID": 5650506,
+         "projectID": 930207,
+         "required": true
+      },
+      {
+         "fileID": 5706069,
+         "projectID": 570017,
+         "required": true
+      },
+      {
          "fileID": 5486070,
          "projectID": 704113,
          "required": true

--- a/manifest.json
+++ b/manifest.json
@@ -322,11 +322,6 @@
          "required": true
       },
       {
-         "fileID": 6210180,
-         "projectID": 899487,
-         "required": true
-      },
-      {
          "fileID": 5486070,
          "projectID": 704113,
          "required": true


### PR DESCRIPTION
Removes better chunk loading because it's the suspected culprit of a server crashing bug that happens pretty frequently

Adds mods listed in[ Rak6's Minecraft Optimization guide](https://github.com/Radk6/MC-Optimization-Guide/blob/main/mods-n-stuff/1.20.1.md).
-AllTheLeaks
-Cull Less Leaves Reforged
-Entity Culling
-ImmediatelyFast
-Noisium
-Radium