### PR TITLE
Replace written book quest reward with clipboard

### DIFF
--- a/config/ftbquests/quests/chapters/welcome.snbt
+++ b/config/ftbquests/quests/chapters/welcome.snbt
@@ -194,7 +194,7 @@
 			id: "00003FCBB33E62C4"
 			rewards: [{
 				id: "67E25D801A479C56"
-				item: "minecraft:writable_book"
+				item: "create:clipboard"
 				type: "item"
 			}]
 			shape: "hexagon"


### PR DESCRIPTION
**Describe the PR**
Replaces the written book quest reward from the welcome chapter with a clipboard from Create. I imagine the original 1.16 version of the pack intended for the book to be used as a way of keeping a checklist so this would be a perfect alternative.

**Screenshots**
![image](https://github.com/user-attachments/assets/702f2d15-f043-4c5f-905e-b5f12eceafdc)
