### PR TITLE
Unify dough

### DIFF
--- a/kubejs/server_scripts/key_mods/create.js
+++ b/kubejs/server_scripts/key_mods/create.js
@@ -49,4 +49,10 @@ ServerEvents.recipes(event => {
         Item.of(Item.of("minecraft:gold_nugget", 2)).withChance(0.125),
         Item.of("minecraft:dead_bush").withChance(0.05)
     ], "minecraft:red_sand")
+
+    // unify dough and allow the slime recipe to take dough from farmer's delight
+    event.remove({ id: "create:crafting/appliances/dough" })
+    event.replaceOutput({ id: "farmersdelight:wheat_dough_from_water" }, 'farmersdelight:wheat_dough', 'create:dough')
+    event.replaceOutput({ id: "farmersdelight:wheat_dough_from_eggs" }, 'farmersdelight:wheat_dough', 'create:dough')
+    event.replaceInput({ id: "create:crafting/appliances/slime_ball" }, 'create:dough', '#forge:dough')
 })


### PR DESCRIPTION
**Describe the PR**
Removes Create's dough recipe as it's identical to the farmer's delight recipe. Replaces the outputs on both Farmer's Delight dough recipes to return Create dough. Slimeball from dough recipe now accepts #forge:dough item tag. Fixes #231

**Screenshots**
![image](https://github.com/user-attachments/assets/6161a30d-08bf-4efe-8129-fac2ff6f2eed)
![image](https://github.com/user-attachments/assets/0c253451-8f27-4bd5-952c-668d8ea8b0fe)
