### PR TITLE
Contraption Compatability (and some bonus Tinkers integration too)

### DIFF
--- a/kubejs/server_scripts/tags.js
+++ b/kubejs/server_scripts/tags.js
@@ -273,6 +273,7 @@ ServerEvents.tags("block", event => {
     // I really don't know why these blocks are missing the pressure plate tag
     // All the other pressure plates from quark and forbidden have the tag.
     event.add("minecraft:pressure_plates", "forbidden_arcanus:polished_darkstone_pressure_plate")
+    
     // Add tags to basic vanilla-like chests and inventories to allow function with create contraptions
     event.get('create:chest_mounted_storage')
         // Quark chests

--- a/kubejs/server_scripts/tags.js
+++ b/kubejs/server_scripts/tags.js
@@ -273,4 +273,28 @@ ServerEvents.tags("block", event => {
     // I really don't know why these blocks are missing the pressure plate tag
     // All the other pressure plates from quark and forbidden have the tag.
     event.add("minecraft:pressure_plates", "forbidden_arcanus:polished_darkstone_pressure_plate")
+    // Add tags to basic vanilla-like chests and inventories to allow function with create contraptions
+    event.get('create:chest_mounted_storage')
+        // Quark chests
+        .add(/^quark:.*_chest$|^everycomp:q.*_chest$/)
+    event.get('create:simple_mounted_storage')
+        // Farmer's Delight cabinets
+        .add(/^farmersdelight:.*_cabinet$|^everycomp:fd.*_cabinet$/)
+        // AE2 Sky stone chests (These don't work with the create:chest_mounted_storage tag for some reason so they are here instead)
+        .add('ae2:sky_stone_chest')
+        .add('ae2:smooth_sky_stone_chest')
+})
+
+ServerEvents.tags("block_entity_type", event => {
+
+    // Add tags to basic vanilla-like chests and inventories to allow function with tinker's side inventory feature on crafting stations
+    event.get('tconstruct:side_inventories')
+        // Quark chests
+        .add('quark:variant_chest')
+        .add('quark:variant_trapped_chest')
+        .add(/^everycomp:q.*_chest$/)
+        // Farmer's Delight cabinets
+        .add('farmersdelight:cabinet')
+        // AE2 Sky stone chests
+        .add('ae2:sky_chest')
 })


### PR DESCRIPTION
**Describe the PR**
Adds some block tags  to select inventories to improve how they interact with contraptions, namely `#create:chest_mounted_storage` and `#create:simple_mounted_storage`. Quark's variant chests, Farmer's Delight cabinets, and AE2 sky stone chests should now be openable on contraptions and capable of storing items collected by contraption actors. This partially fixes #214, I suggest adding https://www.curseforge.com/minecraft/mc-mods/sophisticated-storage-create-integration to the pack as well, that should cover everything except for drawers.

Slightly out of scope for this PR but since I was messing with tags anyways I figured it'd be a good idea to throw in some support for the Tinker's crafting station too. Added the `#tconstruct:side_inventories` block entity type tag (i have no idea why they went with this instead of a normal block tag) to the same inventories as above as they seem not to have any issues in my testing.

**Screenshots**
![image](https://github.com/user-attachments/assets/8df53647-f0ac-4ec7-93b8-789092d37acb)
![image](https://github.com/user-attachments/assets/b45b73d0-9152-4558-82bb-5bb86e64a189)
