### PR TITLE
Better integration of Aquaculture 2 with Farmer's Delight

### DIFF
--- a/config/aquaculture-common.toml
+++ b/config/aquaculture-common.toml
@@ -4,7 +4,7 @@
 	"Should fish be added as compostables for the composter/worm farm? (Based on fish, or weight if enabled)" = true
 	"Should Aquaculture fish be able to be used to breed cats & ocelots?" = true
 	"Enable debug mode? (Enables additional logging)" = false
-	"Show Fillet recipes in JEI?" = true
+	"Show Fillet recipes in JEI?" = false
 	#Range: 0 ~ 63
 	"How many blocks below sea level Aquaculture fish can spawn" = 13
 

--- a/kubejs/client_scripts/bulkhide.js
+++ b/kubejs/client_scripts/bulkhide.js
@@ -170,6 +170,13 @@ JEIEvents.hideItems(event => {
     event.hide("chiselsandbits:block_bit")
 
     event.hide("trials:crafter")
+
+    event.hide("aquaculture:wooden_fillet_knife")
+    event.hide("aquaculture:stone_fillet_knife")
+    event.hide("aquaculture:iron_fillet_knife")
+    event.hide("aquaculture:gold_fillet_knife")
+    event.hide("aquaculture:diamond_fillet_knife")
+    event.hide("aquaculture:neptunium_fillet_knife")
 })
 
 JEIEvents.hideFluids(event => {

--- a/kubejs/client_scripts/bulkhide.js
+++ b/kubejs/client_scripts/bulkhide.js
@@ -176,7 +176,6 @@ JEIEvents.hideItems(event => {
     event.hide("aquaculture:iron_fillet_knife")
     event.hide("aquaculture:gold_fillet_knife")
     event.hide("aquaculture:diamond_fillet_knife")
-    event.hide("aquaculture:neptunium_fillet_knife")
 })
 
 JEIEvents.hideFluids(event => {

--- a/kubejs/server_scripts/mods/aquaculture.js
+++ b/kubejs/server_scripts/mods/aquaculture.js
@@ -12,14 +12,14 @@ if(Platform.isLoaded("aquaculture")) {
 
         let fillet_recipe = (name, count) => {
             event.custom({
-                type: 'farmersdelight:cutting',
+                type: "farmersdelight:cutting",
                 ingredients: [
                     { item: name }
                 ],
-                tool: { tag: 'forge:tools/knives' },
+                tool: { tag: "forge:tools/knives" },
                 result: [
-                    { item: 'aquaculture:fish_fillet_raw', count: count },
-                    { item: 'minecraft:bone_meal'}
+                    { item: "aquaculture:fish_fillet_raw", count: count },
+                    { item: "minecraft:bone_meal"}
                 ]
             })
         }

--- a/kubejs/server_scripts/mods/aquaculture.js
+++ b/kubejs/server_scripts/mods/aquaculture.js
@@ -3,5 +3,76 @@ if(Platform.isLoaded("aquaculture")) {
 
     ServerEvents.recipes(event => {
         event.recipes.create.crushing([Item.of(Item.of("aquaculture:neptunium_ingot", 2)), Item.of(Item.of("aquaculture:neptunium_nugget", 5)).withChance(.5)], "aquaculture:neptunes_bounty").processingTime(500)
+
+        // Note: This does disable the recipe but strangely does not hide it from the recipe viewer
+        // Fortunately this can be done by the config
+        event.remove({ id: "aquaculture:fish_fillet" })
+
+        // Add all fillet recipes to the cutting board
+
+        let fillet_recipe = (name, count) => {
+            event.custom({
+                type: 'farmersdelight:cutting',
+                ingredients: [
+                    { item: name }
+                ],
+                tool: { tag: 'forge:tools/knives' },
+                result: [
+                    { item: 'aquaculture:fish_fillet_raw', count: count },
+                    { item: 'minecraft:bone_meal'}
+                ]
+            })
+        }
+
+        fillet_recipe("minecraft:pufferfish", 1)
+        fillet_recipe("aquaculture:atlantic_cod", 6)
+        fillet_recipe("aquaculture:blackfish", 2)
+        fillet_recipe("aquaculture:pacific_halibut", 12)
+        fillet_recipe("aquaculture:atlantic_halibut", 14)
+        fillet_recipe("aquaculture:atlantic_herring", 1)
+        fillet_recipe("aquaculture:pink_salmon", 2)
+        fillet_recipe("aquaculture:pollock", 2)
+        fillet_recipe("aquaculture:rainbow_trout", 2)
+        fillet_recipe("aquaculture:bayad", 4)
+        fillet_recipe("aquaculture:boulti", 1)
+        fillet_recipe("aquaculture:capitaine", 10)
+        fillet_recipe("aquaculture:synodontis", 1)
+        fillet_recipe("aquaculture:smallmouth_bass", 2)
+        fillet_recipe("aquaculture:bluegill", 1)
+        fillet_recipe("aquaculture:brown_trout", 2)
+        fillet_recipe("aquaculture:carp", 2)
+        fillet_recipe("aquaculture:catfish", 6)
+        fillet_recipe("aquaculture:gar", 4)
+        fillet_recipe("aquaculture:muskellunge", 3)
+        fillet_recipe("aquaculture:perch", 1)
+        fillet_recipe("aquaculture:arapaima", 10)
+        fillet_recipe("aquaculture:piranha", 1)
+        fillet_recipe("aquaculture:tambaqui", 3)
+        fillet_recipe("aquaculture:red_grouper", 3)
+        fillet_recipe("aquaculture:tuna", 10)
+
+        // Remove aquaculture fillet knives as farmer's delight knives are identical in function now
+        event.remove({ id: "aquaculture:wooden_fillet_knife" })
+        event.remove({ id: "aquaculture:stone_fillet_knife" })
+        event.remove({ id: "aquaculture:iron_fillet_knife" })
+        event.remove({ id: "aquaculture:gold_fillet_knife" })
+        event.remove({ id: "aquaculture:diamond_fillet_knife" })
+        event.remove({ id: "aquaculture:neptunium_fillet_knife" })
+    })
+
+    ServerEvents.tags("item", event => {
+        // Adds tags to fish fillet items to allow for their use in more recipes
+        event.add("forge:raw_fishes", "aquaculture:fish_fillet_raw")
+        event.add("farmersdelight:cabbage_roll_ingredients", "aquaculture:fish_fillet_raw")
+        event.add("forge:cooked_fishes", "aquaculture:fish_fillet_cooked")
+
+        // Remove knife tags to prevent them from showing up in EMI
+        event.get("forge:tools/knives")
+            .remove("aquaculture:wooden_fillet_knife")
+            .remove("aquaculture:stone_fillet_knife")
+            .remove("aquaculture:iron_fillet_knife")
+            .remove("aquaculture:gold_fillet_knife")
+            .remove("aquaculture:diamond_fillet_knife")
+            .remove("aquaculture:neptunium_fillet_knife")
     })
 }

--- a/kubejs/server_scripts/mods/aquaculture.js
+++ b/kubejs/server_scripts/mods/aquaculture.js
@@ -57,7 +57,9 @@ if(Platform.isLoaded("aquaculture")) {
         event.remove({ id: "aquaculture:iron_fillet_knife" })
         event.remove({ id: "aquaculture:gold_fillet_knife" })
         event.remove({ id: "aquaculture:diamond_fillet_knife" })
-        event.remove({ id: "aquaculture:neptunium_fillet_knife" })
+
+        // Fix neptunium knife not being unbreakable
+        event.replaceOutput({ id: "aquaculture:neptunium_fillet_knife" }, "aquaculture:neptunium_fillet_knife", Item.of("aquaculture:neptunium_fillet_knife").withNBT({Unbreakable:1, HideFlags:4}))
     })
 
     ServerEvents.tags("item", event => {
@@ -73,6 +75,17 @@ if(Platform.isLoaded("aquaculture")) {
             .remove("aquaculture:iron_fillet_knife")
             .remove("aquaculture:gold_fillet_knife")
             .remove("aquaculture:diamond_fillet_knife")
-            .remove("aquaculture:neptunium_fillet_knife")
+
+        event.get("farmersdelight:tools/knives")
+            .add("aquaculture:neptunium_fillet_knife")
+    })
+
+    // Give neptunium knifes the unbreakable tag so that they don't break when used by deployers
+    PlayerEvents.inventoryChanged("aquaculture:neptunium_fillet_knife", event => {
+        let nbt = event.item.getNbt() || {};
+        nbt.Unbreakable = 1;
+        nbt.HideFlags = 4;
+        event.item.setNbt(nbt);
+        return;
     })
 }


### PR DESCRIPTION
**Describe the PR**
Aquaculture fish are all properly tagged and work for all recipes that accept `#forge:raw_fishes` but due to the sheer variety it's often impractical to actually use them for cooking recipes in practice. Vanilla fish can be cut into slices with Farmer's Delight so this PR gives Aquaculture fish the same treatment. Also moves all fish fillet recipes to the cutting board and adds a bonus bonemeal byproduct for consistency with the existing Farmer's Delight recipes.

**Screenshots**
![image](https://github.com/user-attachments/assets/7a9fe46c-57c6-4641-b9dd-b1fe46a27d03)
![image](https://github.com/user-attachments/assets/3122881e-18b9-45a3-a16c-a8e1aab01e3a)
