### PR TITLE
Fix sticks from logs conflict with Decorative Blocks

### DIFF
--- a/kubejs/server_scripts/mods/quark.js
+++ b/kubejs/server_scripts/mods/quark.js
@@ -56,7 +56,7 @@ if(Platform.isLoaded("quark")) {
     })
 
     ServerEvents.tags("item", event => {
-        //Create a new set of tags for logs ok to use for the easy sticks recipe
+        // Create a new set of tags for logs ok to use for the easy sticks recipe
         const easy_sticks = event.get("minecraft:logs").getObjectIds()
         const easy_sticks_blacklist = Ingredient.of("/.*stripped.*/")
         easy_sticks.forEach(easy_sticks => {

--- a/kubejs/server_scripts/mods/quark.js
+++ b/kubejs/server_scripts/mods/quark.js
@@ -42,6 +42,9 @@ if(Platform.isLoaded("quark")) {
             "below": "minecraft:quartz_block",
             "result": { "item": "quark:jasper"}
         })
+
+        // Modify quark easy sticks recipe to prevent conflicts with decorative blocks wood beams
+        event.replaceInput({ id: "quark:tweaks/crafting/utility/misc/easy_sticks" }, "#minecraft:logs", "#kubejs:easy_sticks_logs")
     })
 
     ServerEvents.tags("block", event => {
@@ -50,6 +53,17 @@ if(Platform.isLoaded("quark")) {
         // I really don't know why these blocks are missing the pressure plate tag
         // All the other pressure plates from quark and forbidden have the tag.
         event.add("minecraft:pressure_plates", "quark:obsidian_pressure_plate")
+    })
+
+    ServerEvents.tags("item", event => {
+        //Create a new set of tags for logs ok to use for the easy sticks recipe
+        const easy_sticks = event.get("minecraft:logs").getObjectIds()
+        const easy_sticks_blacklist = Ingredient.of("/.*stripped.*/")
+        easy_sticks.forEach(easy_sticks => {
+            if (!easy_sticks_blacklist.test(easy_sticks)) event.add("kubejs:easy_sticks_logs", easy_sticks)
+        })
+        // We only want to remove stripped logs, not stripped wood
+        event.add("kubejs:easy_sticks_logs", "#forge:stripped_wood")
     })
 
     ServerEvents.lowPriorityData(event => {


### PR DESCRIPTION
**Describe the PR**
Adds a new tag called `#kubejs:easy_sticks_logs` which includes the contents of `#minecraft:logs` except for stripped logs. Quark now uses this tag for it's sticks to logs recipe. This prevents the recipe from conflicting with the wood beams from decorative blocks, which uses the same shape but with exclusively stripped logs. This approach means the recipe shapes for both remain unchanged and is unlikely to cause breakage.

**Screenshots**
![image](https://github.com/user-attachments/assets/393eb193-c5fe-42ae-b528-ead7791e8550)
