### PR TITLE
Add models to tags to avoid confusion with disabled items

### DIFF
--- a/kubejs/assets/forge/models/tag/item/dough.json
+++ b/kubejs/assets/forge/models/tag/item/dough.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:item/generated",
+  "textures": {
+    "layer0": "create:item/dough"
+  }
+}

--- a/kubejs/assets/forge/models/tag/item/plates.json
+++ b/kubejs/assets/forge/models/tag/item/plates.json
@@ -1,0 +1,7 @@
+{
+  "parent": "emi:item/half_item",
+  "textures": {
+    "first": "create:item/iron_sheet",
+    "second": "create:item/golden_sheet"
+  }
+}

--- a/kubejs/assets/forge/models/tag/item/plates/copper.json
+++ b/kubejs/assets/forge/models/tag/item/plates/copper.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:item/generated",
+  "textures": {
+    "layer0": "create:item/copper_sheet"
+  }
+}

--- a/kubejs/assets/forge/models/tag/item/plates/gold.json
+++ b/kubejs/assets/forge/models/tag/item/plates/gold.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:item/generated",
+  "textures": {
+    "layer0": "create:item/golden_sheet"
+  }
+}

--- a/kubejs/assets/forge/models/tag/item/plates/iron.json
+++ b/kubejs/assets/forge/models/tag/item/plates/iron.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:item/generated",
+  "textures": {
+    "layer0": "create:item/iron_sheet"
+  }
+}

--- a/kubejs/assets/forge/models/tag/item/raw_fishes.json
+++ b/kubejs/assets/forge/models/tag/item/raw_fishes.json
@@ -1,0 +1,7 @@
+{
+  "parent": "emi:item/half_item",
+  "textures": {
+    "first": "minecraft:item/cod",
+    "second": "minecraft:item/salmon"
+  }
+}

--- a/kubejs/assets/forge/models/tag/item/tools/knives.json
+++ b/kubejs/assets/forge/models/tag/item/tools/knives.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:item/generated",
+  "textures": {
+    "layer0": "farmersdelight:item/diamond_knife"
+  }
+}

--- a/kubejs/assets/kubejs/models/tag/item/easy_sticks_logs.json
+++ b/kubejs/assets/kubejs/models/tag/item/easy_sticks_logs.json
@@ -1,0 +1,3 @@
+{
+  "parent": "minecraft:block/oak_log"
+}


### PR DESCRIPTION
**Describe the PR**
Adds models to some tags to change their appearance in the recipe inputs on EMI. More info here **https://github.com/emilyploszaj/emi/wiki/Tag-Translation#tag-models**

Primarily fixes thermal's plates from showing up in crafting recipes when Create's plates are the only ones obtainable, but I also threw in some tag changes for things that bothered me personally.

**Screenshots**
Before
![Screenshot_20250424_072628](https://github.com/user-attachments/assets/4ce67ae0-a3b4-4778-be1d-c1a658220712)
After
![Screenshot_20250424_073032](https://github.com/user-attachments/assets/37830c6f-b325-4e4d-9c70-03e0cc2179d6)
