### PR TITLE
Remove ae2 budding quartz recipes

### DIFF
--- a/kubejs/client_scripts/bulkhide.js
+++ b/kubejs/client_scripts/bulkhide.js
@@ -13,6 +13,11 @@ JEIEvents.hideItems(event => {
 
     event.hide(["ae2:inscriber", "ae2:vibration_chamber"])
     event.hide(/ae2:.*_budding_quartz/)
+    event.hide("ae2:small_quartz_bud")
+    event.hide("ae2:medium_quartz_bud")
+    event.hide("ae2:large_quartz_bud")
+    event.hide("ae2:quartz_cluster")
+    
     event.hide("architects_palette:withered_bone")
 
     let begoneEarth = [

--- a/kubejs/client_scripts/bulkhide.js
+++ b/kubejs/client_scripts/bulkhide.js
@@ -17,7 +17,7 @@ JEIEvents.hideItems(event => {
     event.hide("ae2:medium_quartz_bud")
     event.hide("ae2:large_quartz_bud")
     event.hide("ae2:quartz_cluster")
-    
+
     event.hide("architects_palette:withered_bone")
 
     let begoneEarth = [

--- a/kubejs/server_scripts/key_mods/ae2.js
+++ b/kubejs/server_scripts/key_mods/ae2.js
@@ -1,4 +1,8 @@
 // priority: 1
 ServerEvents.recipes(event => {
     event.remove({ output: "ae2:vibration_chamber" })
+
+    event.remove({ id: "ae2:transform/flawed_budding_quartz" })
+    event.remove({ id: "ae2:transform/chipped_budding_quartz" })
+    event.remove({ id: "ae2:transform/damaged_budding_quartz" })
 })


### PR DESCRIPTION
**Describe the PR**
Budding quartz was already hidden but could still be crafted. Placed budding quartz immediately turns to normal certus quartz resulting in confusion. This PR removes the recipes entirely. Fixes #247 I guess?