### PR TITLE
Make Filter Unloader mineable and drop loot

### DIFF
--- a/kubejs/server_scripts/mods/moreminecarts.js
+++ b/kubejs/server_scripts/mods/moreminecarts.js
@@ -18,7 +18,7 @@ if(Platform.isLoaded("moreminecarts")) {
             .add("moreminecarts:pearl_stasis_chamber")
     })
     LootJS.modifiers((event) => {
-        event.addBlockLootModifier('moreminecarts:filter_unloader')
+        event.addBlockLootModifier("moreminecarts:filter_unloader")
             .addLoot("moreminecarts:filter_unloader")
     })
 }

--- a/kubejs/server_scripts/mods/moreminecarts.js
+++ b/kubejs/server_scripts/mods/moreminecarts.js
@@ -14,6 +14,11 @@ if(Platform.isLoaded("moreminecarts")) {
             .add("moreminecarts:chunk_loader")
             .add("moreminecarts:minecart_loader")
             .add("moreminecarts:minecart_unloader")
+            .add("moreminecarts:filter_unloader")
             .add("moreminecarts:pearl_stasis_chamber")
+    })
+    LootJS.modifiers((event) => {
+        event.addBlockLootModifier('moreminecarts:filter_unloader')
+            .addLoot("moreminecarts:filter_unloader")
     })
 }


### PR DESCRIPTION
**Describe the PR**
For some reason, simply adding the mineable tag isn't enough. 
I had to use LootJS to manually add loot drop.

