### PR TITLE
Fix supplementaries soap dye removal feature setting some items to the wrong color.

### DIFF
--- a/config/supplementaries-common.toml
+++ b/config/supplementaries-common.toml
@@ -337,7 +337,7 @@
 	[functional.soap]
 		enabled = true
 		#Dyed Bock types that cannot be cleaned with soap
-		clean_blacklist = ["minecraft:glazed_terracotta", "botania:mystical_flower", "mna:chimerite_crystal", "botania:floating_flower", ",minecraft:mushroom", "botania:mushroom", "botania:tall_mystical_flower", "botania:petal_block", "morered:network_cable", "xycraft_world:glowing_shiny_aurey_block", "xycraft_world:shiny_aurey_block", "xycraft_world:rgb_lamp", "xycraft_world:glowing_rgb_viewer", "xycraft_world:glowing_matte_rgb_block", "xycraft_world:rgb_lamp_pole"]
+		clean_blacklist = ["minecraft:glazed_terracotta", "botania:mystical_flower", "mna:chimerite_crystal", "botania:floating_flower", ",minecraft:mushroom", "botania:mushroom", "botania:tall_mystical_flower", "botania:petal_block", "morered:network_cable", "xycraft_world:glowing_shiny_aurey_block", "xycraft_world:shiny_aurey_block", "xycraft_world:rgb_lamp", "xycraft_world:glowing_rgb_viewer", "xycraft_world:glowing_matte_rgb_block", "xycraft_world:rgb_lamp_pole", "create:valve_handle", "create:toolbox"]
 
 		#This is a map of special blocks that can be cleaned with soap
 		[functional.soap.special_blocks]
@@ -345,6 +345,8 @@
 			"quark:dirty_glass" = "minecraft:glass"
 			"minecraft:sticky_piston" = "minecraft:piston"
 			"quark:dirty_glass_pane" = "minecraft:glass_pane"
+			"#kubejs:valve_handles_dyed" = "create:copper_valve_handle"
+			"#kubejs:toolboxes_dyed" = "create:brown_toolbox"
 
 	[functional.cannon]
 		enabled = true

--- a/kubejs/server_scripts/mods/supplementaries.js
+++ b/kubejs/server_scripts/mods/supplementaries.js
@@ -24,6 +24,14 @@ if (Platform.isLoaded("supplementaries")) {
         event.stonecutting("supplementaries:timber_frame", "#kubejs:timber_frame")
         event.stonecutting("supplementaries:timber_brace", "#kubejs:timber_frame")
         event.stonecutting("supplementaries:timber_cross_brace", "#kubejs:timber_frame")
+
+        // Fix crafting table dye removal recipes for these items
+        event.shapeless(Item.of("create:copper_valve_handle"), ["#create:valve_handles","supplementaries:soap"] ).id("kubejs:soap_clean_valve_handle_manual_only")
+        // Copy the NBT data for this one so that removing dye doesn't eat our stuff.
+        event.shapeless(Item.of("create:brown_toolbox"), ["#create:toolboxes","supplementaries:soap"] ).id("kubejs:soap_clean_toolbox_manual_only").modifyResult((grid, result) => {
+        const item = grid.find(Ingredient.of("#create:toolboxes"))
+            return result.withNBT(item.nbt)
+        })
     })
 
     ServerEvents.tags("item", event => {
@@ -31,5 +39,19 @@ if (Platform.isLoaded("supplementaries")) {
             .add("supplementaries:timber_frame")
             .add("supplementaries:timber_brace")
             .add("supplementaries:timber_cross_brace")
+    })
+
+    ServerEvents.tags("block", event => {
+        // Whitelist these items to allow the removal of dye in-world using soap (see supplementaries common config)
+        const dyedHandles = event.get("create:valve_handles").getObjectIds()
+        const dyedHandlesBlacklist = Ingredient.of(/.*copper.*/)
+        dyedHandles.forEach(handle => {
+            if (!dyedHandlesBlacklist.test(handle)) event.add("kubejs:valve_handles_dyed", handle)
+        })
+        const dyedToolboxes = event.get("create:toolboxes").getObjectIds()
+        const dyedToolboxesBlacklist = Ingredient.of(/.*brown.*/)
+        dyedToolboxes.forEach(toolbox => {
+            if (!dyedToolboxesBlacklist.test(toolbox)) event.add("kubejs:toolboxes_dyed", toolbox)
+        })
     })
 }

--- a/kubejs/server_scripts/mods/supplementaries.js
+++ b/kubejs/server_scripts/mods/supplementaries.js
@@ -29,7 +29,7 @@ if (Platform.isLoaded("supplementaries")) {
         event.shapeless(Item.of("create:copper_valve_handle"), ["#create:valve_handles","supplementaries:soap"] ).id("kubejs:soap_clean_valve_handle_manual_only")
         // Copy the NBT data for this one so that removing dye doesn't eat our stuff.
         event.shapeless(Item.of("create:brown_toolbox"), ["#create:toolboxes","supplementaries:soap"] ).id("kubejs:soap_clean_toolbox_manual_only").modifyResult((grid, result) => {
-        const item = grid.find(Ingredient.of("#create:toolboxes"))
+            const item = grid.find(Ingredient.of("#create:toolboxes"))
             return result.withNBT(item.nbt)
         })
     })


### PR DESCRIPTION
**Describe the PR**
Before soap would set the color of a valve handle or toolbox to white when the original versions are copper and brown respectively. This PR fixes this for both in world and crafting table interactions, and takes care to preserve the inventory contents of a toolbox when removing it's color.