### PR TITLE
Re-add sapphire and ruby dust pulverizer recipes

### DIFF
--- a/kubejs/server_scripts/recipes/gem_processing.js
+++ b/kubejs/server_scripts/recipes/gem_processing.js
@@ -10,6 +10,9 @@ ServerEvents.recipes(event => {
     event.remove({ id: "thermal:machines/pulverizer/pulverizer_cinnabar" })
     event.recipes.thermal.pulverizer(Item.of("minecraft:redstone", 8), "thermal:cinnabar", 0, 10000)
 
+    event.recipes.thermal.pulverizer("thermal:sapphire_dust", "thermal:sapphire", 0, 4000)
+    event.recipes.thermal.pulverizer("thermal:ruby_dust", "thermal:ruby", 0, 4000)
+
     event.recipes.create.milling("thermal:sulfur_dust", "#forge:gems/sulfur").processingTime(500)
     event.recipes.create.milling("thermal:niter_dust", "#forge:gems/niter").processingTime(500)
     event.recipes.create.milling("thermal:apatite_dust", "#forge:gems/apatite").processingTime(500)


### PR DESCRIPTION
**Describe the PR**
- **Currently, the only way to manufacture ruby + sapphire dusts (needed for reagents) is through Occultism's crushing recipes.** 
- Diamond and emerald dusts have pulverizer recipes, so it should make sense ruby and sapphire should too.
- Matched MJ cost to emerald dust pulverizer recipe (4000).

**Screenshots**
OG emerald cost:
![image](https://github.com/user-attachments/assets/154bac33-a4c2-43cc-9e99-1fd65bdfbcf5)
Ruby:
![image](https://github.com/user-attachments/assets/86752eef-f1df-4927-b335-9088cfd85825)
Sapphire
![image](https://github.com/user-attachments/assets/fa6e25ff-e545-45b0-b45c-befb5cae7c22)

**Additional context**
Add any other context about the PR here.
