### PR TITLE
Add create:fan_transparent tag to copper grates

### DIFF
--- a/kubejs/server_scripts/tags.js
+++ b/kubejs/server_scripts/tags.js
@@ -282,7 +282,7 @@ ServerEvents.tags("block", event => {
         .add(/trials:copper_grate*/)
         .add(/trials:waxed_copper_grate*/)
         .add(/kubejs:trial_copper_grate*/)
-    
+
     // Add tags to basic vanilla-like chests and inventories to allow function with create contraptions
     event.get("create:chest_mounted_storage")
         .add(/^quark:.*_chest$|^everycomp:q.*_chest$/)

--- a/kubejs/server_scripts/tags.js
+++ b/kubejs/server_scripts/tags.js
@@ -277,7 +277,12 @@ ServerEvents.tags("block", event => {
 
     event.add("create:wrench_pickup", "cb_multipart:multipart")
 
-
+    // Add tags to copper grates to allow fans to process through them
+    event.get("create:fan_transparent")
+        .add(/trials:copper_grate*/)
+        .add(/trials:waxed_copper_grate*/)
+        .add(/kubejs:trial_copper_grate*/)
+    
     // Add tags to basic vanilla-like chests and inventories to allow function with create contraptions
     event.get("create:chest_mounted_storage")
         .add(/^quark:.*_chest$|^everycomp:q.*_chest$/)


### PR DESCRIPTION
**Describe the PR**
Exactly as said in title. Parity with Create's behavior in <1.21 with vanilla copper grates.