### PR TITLE
Create Ore Excavation compatibility script

### DIFF
--- a/kubejs/server_scripts/server_compatability/createoreexcavation.js
+++ b/kubejs/server_scripts/server_compatability/createoreexcavation.js
@@ -1,0 +1,193 @@
+if(Platform.isLoaded("createoreexcavation")) {
+    ServerEvents.recipes(event=> {
+
+//Items
+        event.shaped("1x createoreexcavation:vein_finder", [
+            "  A" ,
+            " B " ,
+            "C  " 
+	], {
+            A: "minecraft:ender_eye" ,
+            B: "create:precision_mechanism" ,
+            C: "minecraft:stick"
+	})
+
+//Extraction Machines
+        brassMachine(event, Item.of("createoreexcavation:sample_drill", 1), "thermal:drill_head")
+
+        event.remove({output: "createoreexcavation:drilling_machine"})
+        event.recipes.create.mechanical_crafting("createoreexcavation:drilling_machine", [
+            " ADA " ,
+            "ACBCA" ,
+            "EBBBE" ,
+            "GAFAG" ,
+            "GAFAG"
+        ], {
+            A: "#forge:plates/brass" ,
+            D: "kubejs:copper_machine" ,
+            C: "create:precision_mechanism" ,
+            B: "kubejs:brass_machine" ,
+            E: "create:brass_block" ,
+            F: "create:mechanical_drill" ,
+            G: "create:metal_girder"
+        })
+
+        event.remove({output: "createoreexcavation:extractor"})
+        event.recipes.create.mechanical_crafting("createoreexcavation:extractor", [
+            " ADA " ,
+            "ACBCA" ,
+            "FBEBF" ,
+            "GABAG" ,
+            "GAFAG"
+        ], {
+            A: "#forge:plates/copper" ,
+            B: "kubejs:copper_machine" ,
+            C: "create:precision_mechanism" ,
+            D: "kubejs:brass_machine" ,
+            E: "create:mechanical_drill" ,
+            F: "create:mechanical_pump" ,
+            G: "create:metal_girder"
+        })
+
+//Ore Tweaks
+//Replace Raw Redstone for Cinnabar
+        event.remove({output: "createoreexcavation:raw_redstone", type: "createoreexcavation:drilling"})
+        event.recipes.createoreexcavation.drilling("thermal:cinnabar", "createoreexcavation:ore_vein_type/redstone", 600)
+            .drill("createoreexcavation:drill")
+        event.recipes.createoreexcavation.drilling("thermal:cinnabar", "createoreexcavation:ore_vein_type/redstone", 300)
+            .drill("createoreexcavation:diamond_drill")
+        event.recipes.createoreexcavation.drilling("thermal:cinnabar", "createoreexcavation:ore_vein_type/redstone", 150)
+            .drill("createoreexcavation:netherite_drill")
+
+//Add Lead Ore
+        event.recipes.createoreexcavation.vein('{"text": "Concentrated Raw Lead"}', "thermal:raw_lead")
+            .placement(500, 128, 999).veinSize(1, 3).biomeWhitelist('minecraft:is_overworld')
+            .id("kubejs:lead_ore")
+
+        event.recipes.createoreexcavation.drilling("create:crushed_raw_lead", "kubejs:lead_ore", 600)
+             .drill("createoreexcavation:drill")
+        event.recipes.createoreexcavation.drilling("create:crushed_raw_lead", "kubejs:lead_ore", 300)
+             .drill("createoreexcavation:diamond_drill")
+        event.recipes.createoreexcavation.drilling("thermal:raw_lead", "kubejs:lead_ore", 1200)
+             .drill("createoreexcavation:netherite_drill")
+
+//Drill Retiers
+//Iron Drill, slowest
+
+        event.remove({output: "createoreexcavation:drill"})
+        event.shaped("1x createoreexcavation:drill", [
+            " AC",
+            " AA",
+            "B  ",
+        ], {
+            A: "minecraft:iron_block",
+            B: "thermal:drill_head",
+            C: "kubejs:zinc_machine"
+        })
+
+        event.remove({output: "minecraft:coal", type: "createoreexcavation:drilling"})
+        event.recipes.createoreexcavation.drilling("minecraft:coal", "createoreexcavation:ore_vein_type/coal", 600)
+             .drill("createoreexcavation:drill")
+        event.recipes.createoreexcavation.drilling("minecraft:coal", "createoreexcavation:ore_vein_type/coal", 300)
+             .drill("createoreexcavation:diamond_drill")
+        event.recipes.createoreexcavation.drilling("minecraft:coal", "createoreexcavation:ore_vein_type/coal", 150)
+             .drill("createoreexcavation:netherite_drill")
+
+        event.remove({output: "minecraft:raw_iron", type: "createoreexcavation:drilling"})
+        event.recipes.createoreexcavation.drilling("create:crushed_raw_iron", "createoreexcavation:ore_vein_type/iron", 600)
+             .drill("createoreexcavation:drill")
+        event.recipes.createoreexcavation.drilling("create:crushed_raw_iron", "createoreexcavation:ore_vein_type/iron", 300)
+             .drill("createoreexcavation:diamond_drill")
+        event.recipes.createoreexcavation.drilling("minecraft:raw_iron", "createoreexcavation:ore_vein_type/iron", 1200)
+             .drill("createoreexcavation:netherite_drill")
+
+        event.remove({output: "minecraft:lapis_lazuli", type: "createoreexcavation:drilling"})
+        event.recipes.createoreexcavation.drilling("minecraft:lapis_lazuli", "createoreexcavation:ore_vein_type/lapis", 200)
+             .drill("createoreexcavation:drill")
+    //48 per minute at 256
+        event.recipes.createoreexcavation.drilling("minecraft:lapis_lazuli", "createoreexcavation:ore_vein_type/lapis", 100)
+             .drill("createoreexcavation:diamond_drill")
+    //96 per minute at 256
+        event.recipes.createoreexcavation.drilling("minecraft:lapis_ore", "createoreexcavation:ore_vein_type/lapis", 600)
+             .drill("createoreexcavation:netherite_drill")
+    //16 per minute, crushed into 160 per minute
+
+        event.remove({output: "minecraft:raw_copper", type: "createoreexcavation:drilling"})
+        event.recipes.createoreexcavation.drilling("create:crushed_raw_copper", "createoreexcavation:ore_vein_type/copper", 600)
+             .drill("createoreexcavation:drill")
+        event.recipes.createoreexcavation.drilling("create:crushed_raw_copper", "createoreexcavation:ore_vein_type/copper", 300)
+             .drill("createoreexcavation:diamond_drill")
+        event.recipes.createoreexcavation.drilling("minecraft:raw_copper", "createoreexcavation:ore_vein_type/copper", 1200)
+             .drill("createoreexcavation:netherite_drill")
+
+        event.remove({output: "create:raw_zinc", type: "createoreexcavation:drilling"})
+        event.recipes.createoreexcavation.drilling("create:crushed_raw_zinc", "createoreexcavation:ore_vein_type/zinc", 600)
+             .drill("createoreexcavation:drill")
+        event.recipes.createoreexcavation.drilling("create:crushed_raw_zinc", "createoreexcavation:ore_vein_type/zinc", 300)
+             .drill("createoreexcavation:diamond_drill")
+        event.recipes.createoreexcavation.drilling("create:raw_zinc", "createoreexcavation:ore_vein_type/zinc", 1200)
+             .drill("createoreexcavation:netherite_drill")
+
+        event.remove({output: "minecraft:quartz", type: "createoreexcavation:drilling"})
+        event.recipes.createoreexcavation.drilling("minecraft:quartz", "createoreexcavation:ore_vein_type/quartz", 600)
+             .drill("createoreexcavation:drill")
+        event.recipes.createoreexcavation.drilling("minecraft:quartz", "createoreexcavation:ore_vein_type/quartz", 300)
+             .drill("createoreexcavation:diamond_drill")
+        event.recipes.createoreexcavation.drilling("minecraft:nether_quartz_ore", "createoreexcavation:ore_vein_type/quartz", 300)
+             .drill("createoreexcavation:netherite_drill")
+
+        event.remove({output: "minecraft:glowstone_dust", type: "createoreexcavation:drilling"})
+        event.recipes.createoreexcavation.drilling("minecraft:glowstone_dust", "createoreexcavation:ore_vein_type/glowstone", 400)
+             .drill("createoreexcavation:drill")
+        event.recipes.createoreexcavation.drilling("minecraft:glowstone_dust", "createoreexcavation:ore_vein_type/glowstone", 200)
+             .drill("createoreexcavation:diamond_drill")
+        event.recipes.createoreexcavation.drilling("minecraft:glowstone", "createoreexcavation:ore_vein_type/glowstone", 400)
+             .drill("createoreexcavation:netherite_drill")
+
+        event.remove({output: "minecraft:raw_gold", type: "createoreexcavation:drilling"})
+        event.recipes.createoreexcavation.drilling("create:crushed_raw_gold", "createoreexcavation:ore_vein_type/gold", 600)
+             .drill("createoreexcavation:drill")
+        event.recipes.createoreexcavation.drilling("create:crushed_raw_gold", "createoreexcavation:ore_vein_type/gold", 300)
+             .drill("createoreexcavation:diamond_drill")
+        event.recipes.createoreexcavation.drilling("minecraft:raw_gold", "createoreexcavation:ore_vein_type/gold", 1200)
+             .drill("createoreexcavation:netherite_drill")
+
+//Diamond Drill, fastest
+
+        event.remove({output: "createoreexcavation:diamond_drill"})
+        event.shaped("1x createoreexcavation:diamond_drill", [
+            " AC",
+            " DA",
+            "B  ",
+        ], {
+            A: "minecraft:diamond_block",
+            B: "createoreexcavation:drill",
+            C: "thermal:machine_frame",
+            D: "minecraft:diamond"
+        })
+
+        event.remove({input: "createoreexcavation:raw_diamond"})
+        event.recipes.create.crushing(["minecraft:diamond", Item.of("minecraft:diamond").withChance(0.5)], "createoreexcavation:raw_diamond")
+        event.remove({output: "minecraft:diamond", type: "createoreexcavation:drilling"})
+        event.remove({output: "createoreexcavation:raw_diamond", type: "createoreexcavation:drilling"})
+        event.recipes.createoreexcavation.drilling("minecraft:diamond", "createoreexcavation:ore_vein_type/diamond", 600)
+             .drill("createoreexcavation:diamond_drill")
+        event.recipes.createoreexcavation.drilling("createoreexcavation:raw_diamond", "createoreexcavation:ore_vein_type/diamond", 1200)
+             .drill("createoreexcavation:netherite_drill")
+
+        event.remove({output: "minecraft:emerald", type: "createoreexcavation:drilling"})
+        event.remove({output: "createoreexcavation:raw_emerald", type: "createoreexcavation:drilling"})
+        event.recipes.createoreexcavation.drilling("minecraft:emerald", "createoreexcavation:ore_vein_type/emerald", 600)
+             .drill("createoreexcavation:diamond_drill")
+        event.recipes.createoreexcavation.drilling("minecraft:emerald", "createoreexcavation:ore_vein_type/emerald", 400)
+             .drill("createoreexcavation:netherite_drill")
+
+//Netherite Drill, slowest, but allows extracting concentrated ore instead
+
+        event.remove({output: "createoreexcavation:netherite_drill"})
+        event.smithing("createoreexcavation:netherite_drill", "kubejs:enderium_machine", "createoreexcavation:diamond_drill", "minecraft:netherite_ingot")
+		
+        event.recipes.createoreexcavation.drilling("createoreexcavation:raw_diamond", "createoreexcavation:ore_vein_type/hardened_diamond", 600)
+             .drill("createoreexcavation:netherite_drill") 
+    })
+}


### PR DESCRIPTION
Create Ore Excavation compatibility script.
Including new recipes for all machines and hardened diamond, new vein for lead, replacement of raw redstone for cinnabar, tiering of all drills, iron is the first, diamond is the fastest, netherite is the slowest but can extract raw ore.

![Captura de pantalla 2025-06-26 184703](https://github.com/user-attachments/assets/acb6792c-a760-4025-a77a-bb85e0481bea)

![Captura de pantalla 2025-06-26 184649](https://github.com/user-attachments/assets/ab40d4f5-ab7d-4a6c-9c17-53cc3e3cc458)

![Captura de pantalla 2025-06-26 184657](https://github.com/user-attachments/assets/554948e7-a6bc-496c-825f-0bcc08b54aff)

![Captura de pantalla 2025-06-26 184721](https://github.com/user-attachments/assets/019339da-c101-4b8a-a376-54f3543370e4)

![Captura de pantalla 2025-06-26 191918](https://github.com/user-attachments/assets/e533f4f7-1029-479d-b81b-22d3792405d0)

![Captura de pantalla 2025-06-26 191927](https://github.com/user-attachments/assets/71cbca9a-9020-48fd-b494-03d5bde88a6a)

