### PR TITLE
Temporary fix for unbreakable ingredients

### DIFF
--- a/config/ftbquests/quests/chapters/market.snbt
+++ b/config/ftbquests/quests/chapters/market.snbt
@@ -90,24 +90,7 @@
 			id: "4F953BACF4D1C151"
 			rewards: [{
 				id: "56DB21D18FB1FF64"
-				item: {
-					Count: 1
-					id: "cb_microblock:diamond_saw"
-					tag: {
-						Damage: 0
-						Enchantments: [{
-							id: "minecraft:unbreaking"
-							lvl: 10s
-						}]
-						HideFlags: 1
-						RepairCost: 0
-						Unbreakable: 1
-						display: {
-							Lore: ["{\"text\":\"Do not use in manual crafting\"}"]
-							Name: "{\"text\":\"Enchanted Saw\",\"color\":\"gold\",\"italic\":false}"
-						}
-					}
-				}
+				item: "kubejs:enchanted_saw"
 				type: "item"
 			}]
 			subtitle: "{cabin.quest.4F953BACF4D1C151.subtitle}"
@@ -151,22 +134,7 @@
 			id: "72CACE8F0E4701B1"
 			rewards: [{
 				id: "743730BBE32A0875"
-				item: {
-					Count: 1
-					id: "projectred_core:screwdriver"
-					tag: {
-						Damage: 0
-						Enchantments: [{
-							id: "minecraft:unbreaking"
-							lvl: 10s
-						}]
-						HideFlags: 1
-						Unbreakable: 1
-						display: {
-							Name: "{\"text\":\"Enchanted Screwdriver\",\"color\":\"gold\",\"italic\":false}"
-						}
-					}
-				}
+				item: "kubejs:enchanted_screwdriver"
 				type: "item"
 			}]
 			subtitle: "{cabin.quest.4F953BACF4D1C151.subtitle}"
@@ -210,22 +178,7 @@
 			id: "43FC566E833BE834"
 			rewards: [{
 				id: "0F4C7BB4C0ECB4CC"
-				item: {
-					Count: 1
-					id: "kubejs:chromatic_resonator"
-					tag: {
-						Damage: 0
-						Enchantments: [{
-							id: "minecraft:unbreaking"
-							lvl: 10s
-						}]
-						HideFlags: 1
-						Unbreakable: 1
-						display: {
-							Name: "{\"text\":\"Enchanted Resonator\",\"color\":\"gold\",\"italic\":false}"
-						}
-					}
-				}
+				item: "kubejs:enchanted_chromatic_resonator"
 				type: "item"
 			}]
 			subtitle: "{cabin.quest.00D6DD6AE8E3C014.subtitle}"
@@ -667,22 +620,7 @@
 			id: "00D6DD6AE8E3C014"
 			rewards: [{
 				id: "3EA7518063CBEA5B"
-				item: {
-					Count: 1
-					id: "kubejs:flash_drive"
-					tag: {
-						Damage: 0
-						Enchantments: [{
-							id: "minecraft:unbreaking"
-							lvl: 10s
-						}]
-						HideFlags: 1
-						Unbreakable: 1
-						display: {
-							Name: "{\"text\":\"Enchanted Flash Drive\",\"color\":\"gold\",\"italic\":false}"
-						}
-					}
-				}
+				item: "kubejs:enchanted_flash_drive"
 				type: "item"
 			}]
 			subtitle: "{cabin.quest.00D6DD6AE8E3C014.subtitle}"

--- a/kubejs/server_scripts/recipes/unbreakable_fix.js
+++ b/kubejs/server_scripts/recipes/unbreakable_fix.js
@@ -1,0 +1,12 @@
+ServerEvents.recipes(event => {
+  // Generates new recipes for the mechanisms that does not consume the tool in the deploying process if they are the "Enchanted" (unbreakable) ones
+  function unbreakableRecipe(toolid, mechanismid) {
+    event.recipes.create
+      .deploying(mechanismid, [Item.of(mechanismid.replace(":", ":incomplete_"), "{SequencedAssembly:{Progress:0.6666667f,Step:2}}").weakNBT(), toolid])
+      .keepHeldItem();
+  }
+  unbreakableRecipe("kubejs:enchanted_saw", "kubejs:kinetic_mechanism");
+  unbreakableRecipe("kubejs:enchanted_screwdriver", "create:precision_mechanism");
+  unbreakableRecipe("kubejs:enchanted_chromatic_resonator", "kubejs:inductive_mechanism");
+  unbreakableRecipe("kubejs:enchanted_flash_drive", "kubejs:calculation_mechanism");
+});

--- a/kubejs/startup_scripts/unbreakables.js
+++ b/kubejs/startup_scripts/unbreakables.js
@@ -1,0 +1,17 @@
+StartupEvents.registry("item", event => {
+  // Creates a duplicate tool with a given texture to be used as non-consumable ingredient in auxiliary deployer recipes
+  function createEnchanted(tool, texture) {
+    event
+      .create("enchanted_" + tool.toLowerCase().replace(" ", "_"))
+      .unstackable()
+      .glow(true)
+      .displayName("Enchanted " + tool)
+      .rarity("uncommon")
+      .texture(texture)
+      .tooltip(Text.darkPurple("To be used ONLY with deployers"));
+  }
+  createEnchanted("Saw", "cb_microblock:item/diamond_saw");
+  createEnchanted("Screwdriver", "projectred_core:item/screwdriver");
+  createEnchanted("Chromatic Resonator", "cabin:item/chromatic_resonator");
+  createEnchanted("Flash Drive", "cabin:item/boot_medium");
+});


### PR DESCRIPTION
**Describe the PR**
As a proper fix for #288 will be released whenever Create 6.0.7 is out (which may take a while), this PR attempts to give a temporary fix in order to be able to update to Create 6.0.6

**Additional context**
- Made new (duplicated) items only to be used in the deployer recipes. They have no durability nor can be used in the same recipes as the base ones by default.
- Defined new recipes for that last step of the assemblies. This is a deploying recipe applied to the second step of each compromised mechanism which do not consumes the item being deployed.
- Changed the market items with the new duplicated versions. This means that in order for this fix to be useful, the player will need to reset their quest or #293 would need to be merged (as it makes those quests repeatable)