### PR TITLE
Fixed Gemstone Catalyst not having recipes

### DIFF
--- a/kubejs/server_scripts/recipes/alchemy.js
+++ b/kubejs/server_scripts/recipes/alchemy.js
@@ -35,6 +35,12 @@ ServerEvents.recipes(event => {
     alchemy_smelt("zinc", "metal", "apatite", "slime")
     alchemy_smelt("iron", "metal", "certus", "prismarine")
 
+	alchemy_mix("emerald", "gem", "lead", "certus")
+	alchemy_mix("sapphire", "gem", "copper", "fluix")
+	alchemy_mix("diamond", "gem", "gold", "niter")
+	alchemy_mix("lapis", "gem", "nickel", "quartz")
+	alchemy_mix("ruby", "gem", "zinc", "sulfur")
+	alchemy_mix("cinnabar", "gem", "iron", "apatite")
 
     alchemy_smelt("andesite", "igneous", "emerald", "iron", 20)
     alchemy_smelt("diorite", "igneous", "sapphire", "lead", 20)

--- a/kubejs/server_scripts/recipes/alchemy.js
+++ b/kubejs/server_scripts/recipes/alchemy.js
@@ -35,12 +35,12 @@ ServerEvents.recipes(event => {
     alchemy_smelt("zinc", "metal", "apatite", "slime")
     alchemy_smelt("iron", "metal", "certus", "prismarine")
 
-	alchemy_mix("emerald", "gem", "lead", "certus")
-	alchemy_mix("sapphire", "gem", "copper", "fluix")
-	alchemy_mix("diamond", "gem", "gold", "niter")
-	alchemy_mix("lapis", "gem", "nickel", "quartz")
-	alchemy_mix("ruby", "gem", "zinc", "sulfur")
-	alchemy_mix("cinnabar", "gem", "iron", "apatite")
+    alchemy_mix("emerald", "gem", "lead", "certus")
+    alchemy_mix("sapphire", "gem", "copper", "fluix")
+    alchemy_mix("diamond", "gem", "gold", "niter")
+    alchemy_mix("lapis", "gem", "nickel", "quartz")
+    alchemy_mix("ruby", "gem", "zinc", "sulfur")
+    alchemy_mix("cinnabar", "gem", "iron", "apatite")
 
     alchemy_smelt("andesite", "igneous", "emerald", "iron", 20)
     alchemy_smelt("diorite", "igneous", "sapphire", "lead", 20)


### PR DESCRIPTION
**Description**
Adds gemstone catalyst recipes to improve similarity with Create: Above and Beyond. Currently, the gemstone catalyst has no uses beyond making the chaos catalyst, and ruby and sapphire are impossible to automate without Occultism. This PR adds the recipes to make all of the gemstone reagents like in Create: Above and Beyond.

**Screenshots**
![image](https://github.com/user-attachments/assets/0e1d086f-06c1-408b-8d56-53f3b28678ae)
![image](https://github.com/user-attachments/assets/794967fe-3fb7-4547-8128-3accf79d4038)

**Additional Context**
I've never used the pull request system before, so sorry if this ends up weirdly formatted. I also noticed that there does seem to be a double line break in the original file indicating that the code to make these recipes was originally there and got deleted, but I can't seem to figure out why. Any further information would be greatly appreciated!
