### PR TITLE
Readme Comp Mod Link was wrong 

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 Thank you!
 
 ## Addon Mods (AKA Optional Compats)
-[Compatible Mods List](https://github.com/Mac10goesBRRRT/CABIN/blob/1.20.1/MOD_COMPAT.md)
+[Compatible Mods List](https://github.com/ThePansmith/CABIN/blob/1.20.1/MOD_COMPAT.md)
 
 
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 Thank you!
 
 ## Addon Mods (AKA Optional Compats)
-[Compatible Mods List](https://github.com/ThePansmith/CABIN/blob/1.20.1/mods/compat.md)
+[Compatible Mods List](https://github.com/Mac10goesBRRRT/CABIN/blob/1.20.1/MOD_COMPAT.md)
 
 
 


### PR DESCRIPTION
The Link went to a file that no longer exists.
Updated the Link, now it works.
