### PR TITLE
Add ability to craft Illumar Smart Lamps

### DIFF
--- a/kubejs/server_scripts/mods/projectred_illumination.js
+++ b/kubejs/server_scripts/mods/projectred_illumination.js
@@ -8,6 +8,18 @@ if (Platform.isLoaded("projectred_illumination")) {
             event.shapeless(lamp, [inverted])
         }
 
+        event.shaped(Item.of("projectred_illumination:illumar_smart_lamp", 1), [
+            " C ",
+            "RGB",
+            " S "
+        ], {
+            C: "#forge:glass/colorless",
+            R: "projectred_core:red_illumar",
+            G: "projectred_core:green_illumar",
+            B: "projectred_core:blue_illumar",
+            S: "minecraft:redstone"
+        })
+
         colours.forEach(c => {
             event.shaped(Item.of(`projectred_illumination:${c}_illumar_lamp`, 1), [
                 "G",


### PR DESCRIPTION
**Describe the PR**
Adds a recipe for the Illumar Smart Lamps from ProjectRed Illumination.

**Screenshots**
The proposed crafting recipe:
<img width="370" height="292" alt="image" src="https://github.com/user-attachments/assets/595b280e-f06f-49c9-be56-82c254549c6b" />

**Additional Context**
Currently Illumar Smart Lamps are unable to be crafted. This patch introduces a recipe for them, consisting of Red Illumar, Green Illumar, and Blue Illumar, as well as Redstone Dust and Clear Glass.