### PR TITLE
Adding raw 'crushed' ore block processing

### DIFF
--- a/kubejs/server_scripts/recipes/metallurgy.js
+++ b/kubejs/server_scripts/recipes/metallurgy.js
@@ -344,6 +344,11 @@ ServerEvents.recipes(event => {
         event.recipes.create.crushing([Item.of(dust, 3), Item.of(dust, 3).withChance(0.5)], crushedOre).id("kubejs:ore_processing/crushing/crushed/" + materialName)
         event.recipes.thermal.pulverizer([Item.of(dust, 6)], crushedOre, 0.2, 6400).id("kubejs:ore_processing/pulverizing/crushed/" + materialName)
 
+        // 'crushed'/'raw' ore block to ore dust
+        event.recipes.create.milling([Item.of(dust, 18)], crushedOreBlockTag).id("kubejs:ore_processing/milling/crushed_block/" + materialName)
+        event.recipes.create.crushing([Item.of(dust, 18), Item.of(dust, 18).withChance(0.5)], crushedOreBlockTag).id("kubejs:ore_processing/crushing/crushed_block/" + materialName)
+        event.recipes.thermal.pulverizer([Item.of(dust, 48)], crushedOreBlockTag, 0.2, 6400).id("kubejs:ore_processing/pulverizing/crushed_block/" + materialName)
+
         // ore dust to nuggets
         event.smelting(Item.of(nugget, 1), dustTag).cookingTime(40).id("kubejs:ore_processing/smelting/dust/" + materialName)
 

--- a/kubejs/server_scripts/recipes/metallurgy.js
+++ b/kubejs/server_scripts/recipes/metallurgy.js
@@ -345,9 +345,9 @@ ServerEvents.recipes(event => {
         event.recipes.thermal.pulverizer([Item.of(dust, 6)], crushedOre, 0.2, 6400).id("kubejs:ore_processing/pulverizing/crushed/" + materialName)
 
         // 'crushed'/'raw' ore block to ore dust
-        event.recipes.create.milling([Item.of(dust, 18)], crushedOreBlockTag).id("kubejs:ore_processing/milling/crushed_block/" + materialName)
-        event.recipes.create.crushing([Item.of(dust, 18), Item.of(dust, 18).withChance(0.5)], crushedOreBlockTag).id("kubejs:ore_processing/crushing/crushed_block/" + materialName)
-        event.recipes.thermal.pulverizer([Item.of(dust, 48)], crushedOreBlockTag, 0.2, 6400).id("kubejs:ore_processing/pulverizing/crushed_block/" + materialName)
+        event.recipes.create.milling([Item.of(dust, 27)], crushedOreBlockTag).id("kubejs:ore_processing/milling/crushed_block/" + materialName)
+        event.recipes.create.crushing([Item.of(dust, 27), Item.of(dust, 27).withChance(0.5)], crushedOreBlockTag).id("kubejs:ore_processing/crushing/crushed_block/" + materialName)
+        event.recipes.thermal.pulverizer([Item.of(dust, 54)], crushedOreBlockTag, 0.2, 6400).id("kubejs:ore_processing/pulverizing/crushed_block/" + materialName)
 
         // ore dust to nuggets
         event.smelting(Item.of(nugget, 1), dustTag).cookingTime(40).id("kubejs:ore_processing/smelting/dust/" + materialName)


### PR DESCRIPTION
Reminder : When we mine ore we get 'crushed raw ore'. As well as crushing ore block obtain by silktouch. Vanilla raw ore isn't meant to be obtain.

The purpose of this modification is to be able to crush these "raw ore block" or logically "crushed raw ore block".
For exemple when we create a miner minecart, we store obtainned item in compacting drawer or storage with a compacting upgrade. In this case, it's very convenient to be able to crush directly these "raw ore block".

<img width="834" height="738" alt="image" src="https://github.com/user-attachments/assets/d79a0ea3-67da-4cac-ad2b-d5c30c33c023" />
Supposed to be 27, my bad :P