### PR TITLE
Cinnabar tweaks and fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # Minecraft
 local/
 saves/
-mods/
+/mods/
 logs/
 crash-reports/
 backups/

--- a/kubejs/client_scripts/mods/thermal.js
+++ b/kubejs/client_scripts/mods/thermal.js
@@ -1,0 +1,5 @@
+if(Platform.isLoaded("thermal")) {
+    JEIEvents.hideItems(event => {
+        event.hide("thermal:cinnabar_dust")
+    })
+}

--- a/kubejs/server_scripts/key_mods/thermal.js
+++ b/kubejs/server_scripts/key_mods/thermal.js
@@ -50,6 +50,13 @@ ServerEvents.recipes(event => {
     event.custom({"type": "thermal:gourmand_fuel", "ingredient": {"item": "farmersdelight:cabbage_crate"}, "energy": 32000})
     event.custom({"type": "thermal:gourmand_fuel", "ingredient": {"item": "farmersdelight:onion_crate"}, "energy": 32000})
     event.custom({"type": "thermal:gourmand_fuel", "ingredient": {"item": "farmersdelight:tomato_crate"}, "energy": 16000})
+    // Fix broken cinnabar recipes
+    event.replaceInput(
+    { input: "thermal:cinnabar_ore" },
+    'thermal:cinnabar_ore',
+    "#forge:ores/cinnabar"
+    )
+
     // Igneous Extruder recipes
     let bedrock_cobblegen = (adjacent, output) => {
         event.custom({

--- a/kubejs/server_scripts/key_mods/thermal.js
+++ b/kubejs/server_scripts/key_mods/thermal.js
@@ -56,6 +56,8 @@ ServerEvents.recipes(event => {
     'thermal:cinnabar_ore',
     "#forge:ores/cinnabar"
     )
+    // Remove unused cinnabar dust
+    event.remove({ output: 'thermal:cinnabar_dust'})
 
     // Igneous Extruder recipes
     let bedrock_cobblegen = (adjacent, output) => {

--- a/kubejs/server_scripts/recipes/gem_processing.js
+++ b/kubejs/server_scripts/recipes/gem_processing.js
@@ -5,10 +5,18 @@ ServerEvents.recipes(event => {
     event.recipes.create.crushing([Item.of("thermal:sapphire", 2), Item.of("thermal:sapphire", 1).withChance(.25), experience,stone], "thermal:sapphire_ore")
     event.recipes.create.crushing([Item.of("thermal:ruby", 2), Item.of("thermal:ruby", 1).withChance(.25), experience,stone], "thermal:ruby_ore")
 
+    // cinnabar things :
+    // from gem to dust
     event.recipes.create.milling(Item.of("minecraft:redstone", 4), "thermal:cinnabar").processingTime(700)
     event.recipes.create.crushing(Item.of("minecraft:redstone", 6), "thermal:cinnabar").processingTime(500)
     event.remove({ id: "thermal:machines/pulverizer/pulverizer_cinnabar" })
     event.recipes.thermal.pulverizer(Item.of("minecraft:redstone", 8), "thermal:cinnabar", 0, 10000)
+    
+    // from gem block to dust
+    event.recipes.create.milling(Item.of("minecraft:redstone", 36), "thermal:cinnabar_block").processingTime(700)
+    event.recipes.create.crushing(Item.of("minecraft:redstone", 63), "thermal:cinnabar_block").processingTime(500)
+    event.recipes.thermal.pulverizer(Item.of("minecraft:redstone", 72), "thermal:cinnabar_block", 0, 10000)
+    // end
 
     event.recipes.create.milling("thermal:sulfur_dust", "#forge:gems/sulfur").processingTime(500)
     event.recipes.create.milling("thermal:niter_dust", "#forge:gems/niter").processingTime(500)


### PR DESCRIPTION
### Here's various tweaks and fix :
- Deepslate Cinnabar Ore not blasting or smelting
- Cinnabar dust still present but not used
- Cinnabar block not crushable directly


### Deepslate Cinnabar Ore not blasting or smelting :
This come directly from the thermal foundation mod. I don't know if it has been fixed in newer version, I will take a look.
A workaround with kubejs has been made

### thermal's code not using #forge:ores/cinnabar tag :
```
{
  "type": "minecraft:smelting",
  "category": "misc",
  "cookingtime": 200,
  "experience": 0.5,
  "ingredient": {
    "item": "thermal:cinnabar_ore"
  },
  "result": "thermal:cinnabar"
}
```
```
{
  "type": "minecraft:blasting",
  "category": "misc",
  "cookingtime": 100,
  "experience": 0.5,
  "ingredient": {
    "item": "thermal:cinnabar_ore"
  },
  "result": "thermal:cinnabar"
}
```