### PR TITLE
Better construction wands integration

### DIFF
--- a/config/resourcepackoverrides.json
+++ b/config/resourcepackoverrides.json
@@ -9,6 +9,7 @@
 	"file/Create Computers 1.2.1 - 1.20.1.zip",
 	"file/moromoro's_create_style_prettypipes.zip",
 	"file/CreateSophisticatedBackpacks.zip",
+	"file/Construction_Wands_Creatifyed_v1.zip",
 	"file/CABIN",
 	"file/CABIN Resource Pack Overrides"
   ],

--- a/kubejs/server_scripts/server_compatability/constructionwand.js
+++ b/kubejs/server_scripts/server_compatability/constructionwand.js
@@ -1,0 +1,49 @@
+if(Platform.isLoaded("constructionwand")) {
+    ServerEvents.recipes(event => {
+
+        event.remove({ mod: "constructionwand" })
+
+        // Construction Wands
+        event.shaped("constructionwand:stone_wand", [
+            " S ",
+            "CCC",
+            " H "
+        ], {
+            S: "create:empty_schematic",
+            C: "minecraft:stick",
+            H: "minecraft:cobblestone",
+        })
+        let wand = (id, mechanismTier, gearMaterial, chasisMaterial) => {
+            event.recipes.create.mechanical_crafting("constructionwand:" + id + "_wand", [
+                " S ",
+                "CCC",
+                " M ",
+                " G ",
+                " C "
+            ], {
+                S: "create:empty_schematic",
+                C: chasisMaterial,
+                M: mechanismTier,
+                G: gearMaterial,
+            })
+        }
+        wand("iron", "create:precision_mechanism", "thermal:iron_gear", "minecraft:stick")
+        wand("diamond", "kubejs:inductive_mechanism", "thermal:diamond_gear", "minecraft:stick")
+        wand("infinity", "kubejs:calculation_mechanism", "thermal:invar_gear", "architects_palette:unobtanium")
+
+        // Wand Cores
+        let core = (id, coreType, otherIngredient) => { 
+            event.shaped("constructionwand:core_" + id, [
+                " GD",
+                "GCG",
+                "DG "
+            ], {
+                C: coreType,
+                D: otherIngredient,
+                G: "minecraft:glass_pane"
+            })
+        }
+        core("angel", "minecraft:golden_apple", "minecraft:feather")
+        core("destruction", "ae2:annihilation_core", "minecraft:redstone")
+    })
+}


### PR DESCRIPTION
**Describe the PR**
Reworks all the Construction Wand recipes and their Cores to better fit CABIN's progression.
The recipes by themselves don't make much sense, because they use the "Construction Wands Creatifyed" resourcepack as a reference (Making this an assets PR disguised as a code PR).

**Screenshots**
<img width="513" height="252" alt="image" src="https://github.com/user-attachments/assets/6ed2b3dc-6561-47ef-9441-a881ca28df3f" />
<img width="743" height="463" alt="image" src="https://github.com/user-attachments/assets/e53bdb3b-ed7b-4317-9dc8-3211c3e9eceb" />

**Additional context**
I couldn't figure out how to use Pakku to add the resourcepack myself because I'm dumb, so here's the link:
https://www.curseforge.com/minecraft/texture-packs/construction-wands-creatifyed/files/all?page=1&pageSize=20&showAlphaFiles=hide
