### PR TITLE
Fixed Tin recipes

### DIFF
--- a/kubejs/startup_scripts/nukeLists/item.js
+++ b/kubejs/startup_scripts/nukeLists/item.js
@@ -136,7 +136,16 @@ global.itemNukeList = [
     "thermal:netherite_plate",
     "thermal:servo_attachment",
     "thermal:device_hive_extractor",
-
+    "thermal:tin_ore",
+    "thermal:deepslate_tin_ore",
+    "thermal:tin_nugget",
+    "thermal:tin_ingot",
+    "thermal:tin_block",
+    "thermal:tin_dust",
+    "thermal:tin_plate",
+    "thermal:tin_gear",
+    "thermal:raw_tin",
+    "thermal:raw_tin_block",
     // Trials
     "trials:crafter",
 

--- a/kubejs/startup_scripts/nukeLists/unificationPatterns.js
+++ b/kubejs/startup_scripts/nukeLists/unificationPatterns.js
@@ -3,6 +3,6 @@ global.unificationPattern = new RegExp(
     "^(" +
         "occultism:(silver_(ingot|nugget|block|dust|ore)|raw_silver(_block)?|silver_ore_deepslate|(iron|gold|copper|obsidian)_dust)" +
         "|tconstruct:(steel_(ingot|nugget|block)|copper_nugget)" +
-        "|thermal:(tin_(ingot|nugget|block|dust|ore|plate|gear)|deepslate_tin_ore|raw_tin(_block)?|silver_ore|deepslate_silver_ore|raw_silver(_block)?|copper_nugget|netherite_nugget|ender_pearl_dust)" +
+        "|thermal:(deepslate_tin_ore|raw_tin(_block)?|silver_ore|deepslate_silver_ore|raw_silver(_block)?|copper_nugget|netherite_nugget|ender_pearl_dust)" +
     ")$"
 );


### PR DESCRIPTION
**Describe the PR**
undoes the 2.14 nukelist change. Tin is no longer removed and is instead hidden like before. This allows Tin used it essential game recipes to be replaced with zinc. When you remove Tin during the startup_script phase, it cannot be replaced with zinc as that happens in server_scripts (i believe). 

**Screenshots**
If applicable, add screenshots.

**Additional context**
I am primarily making this pull request to raise awareness of this bug as it is making progression much harder without the ability to make the sequential fabricator or the centrifugal separator as those require tin. I know very little about Minecraft modding so this is just a proof of concept.
