### PR TITLE
Fix numerical inaccuracy in quest

### DIFF
--- a/kubejs/assets/ftbquests/lang/en_us.json
+++ b/kubejs/assets/ftbquests/lang/en_us.json
@@ -262,7 +262,7 @@
     "cabin.quest.1D4B76A3C724C40D.title": "32x Twisted Planks",
     "cabin.quest.1D6150F2480B976E.subtitle": "24 Silver",
     "cabin.quest.1D6150F2480B976E.title": "8x Nether Quartz",
-    "cabin.quest.1D9D65FBD06DD481.description1": "Every Zinc Machine will end up using 144 Buckets of Lava in Production. It's not a great ecological footprint, but even just one Hose Pulley can make quick work of it.",
+    "cabin.quest.1D9D65FBD06DD481.description1": "Every Zinc Machine will end up using 24 Buckets of Lava in Production. It's not a great ecological footprint, but even just one Hose Pulley can make quick work of it.",
     "cabin.quest.1D9D65FBD06DD481.description2": "Remember that trains can cross through nether portals, perhaps this can help you.",
     "cabin.quest.1D9D65FBD06DD481.subtitle": "Contraption 18-1",
     "cabin.quest.1D9D65FBD06DD481.title": "A lot. of lava",


### PR DESCRIPTION
The amount of lava needed for one zinc machine counts 24 buckets, not 144 (anymore).

**Describe the PR**
The Chapter2A quest for contraption 18-1 mentions zinc machines needing 144 buckets of lava, this is changed to mention 24 instead.

**Screenshots**
No screenshots.

**Additional context**
A zinc machine requires 8 mechanisms, and each requires 1 spout of liquid soul, and three spouts of lava. The former takes 500mB per spout, the latter a full bucket. So each mechanism requires 3 buckets of lava (and half of one with liquid soul), so a machine requires 8 x 3 = 24 buckets. Maybe in a previous iteration the sequence had to be repeated 6 times, then it would have been 144 per machine.