### PR TITLE
Fixes multiple Occultism recipes being broken

### DIFF
--- a/kubejs/data/occultism/recipes/ritual/summon_foliot_crusher.json
+++ b/kubejs/data/occultism/recipes/ritual/summon_foliot_crusher.json
@@ -1,0 +1,32 @@
+{
+  "type": "occultism:ritual",
+  "ritual_type": "occultism:summon_spirit_with_job",
+  "activation_item": {
+    "item": "occultism:book_of_binding_bound_foliot"
+  },
+  "pentacle_id": "occultism:summon_foliot",
+  "duration": 60,
+  "spirit_max_age": 32400,
+  "spirit_job_type": "occultism:crush_tier1",
+  "entity_to_summon": "occultism:foliot",
+  "ritual_dummy": {
+    "item": "occultism:ritual_dummy/summon_foliot_crusher"
+  },
+  "ingredients": [
+    {
+      "tag": "forge:dusts/iron"
+    },
+    {
+      "tag": "forge:dusts/gold"
+    },
+    {
+      "tag": "forge:dusts/copper"
+    },
+    {
+      "tag": "forge:dusts/zinc"
+    }
+  ],
+  "result": {
+    "item": "occultism:jei_dummy/none"
+  }
+}

--- a/kubejs/startup_scripts/nukeLists/item.js
+++ b/kubejs/startup_scripts/nukeLists/item.js
@@ -47,7 +47,8 @@ global.itemNukeList = [
     "occultism:debug_djinni_manage_machine",
     "occultism:debug_djinni_test",
     "occultism:lighted_air",
-    "occultism:jei_dummy/none",
+    "occultism:ritual_dummy/custom_ritual",
+    // "occultism:jei_dummy/none",
     "occultism:jei_dummy/require_sacrifice",
     "occultism:jei_dummy/require_item_use",
 


### PR DESCRIPTION
**Describe the PR**
Fixes multiple Occultism recipes being broken due to the 2.1.4 nuke mechanic change.

**Screenshots**
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/9d5610a5-5f22-4b29-acca-7cf1be84a29e" />
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/8e624a4c-9388-4314-8b87-d867961eb61b" />

**Additional context**
I found that multiple Occultism ritual recipes, including summoning sapling/otherstone traders, every tier of crushers, change time/weather, and resurrect familiars are broken from 2.1.4 to 2.1.6. The recipes didn't show up in either EMI or the Dictionary of Spirits, while the ritual dummies did. This issue is mentioned in #426, in which a workaround is proposed by adding an alternative IE recipe.

I've checked that they're working in 2.1.3, suggesting it being a bug caused by the nuke mechanic rework. After some investigation, I identified that the main issue is caused by nuking `occultism:jei_dummy/none`,
which appear in many Occultism recipes as dummy result item in the 1.20.1 version.
After removing the line, all the recipes are back.
The recipe for `summon_foliot_crusher` still appear broken though, particularly the `#forge:raw_materials/silver` wasn't replaced by zinc dust. I tried tinkering with the relevant script but couldn't get it to work. I suspect that's somehow related to how silver ore is removed from the pack.

https://github.com/ThePansmith/CABIN/blob/ad30233439d94bfd8cf3049b14cecef00382fa6f/kubejs/server_scripts/key_mods/occultism.js#L25

So I added a recipe in the `kubejs/data` folder that seemed to override the original recipe just fine, and this fixed the issue.

While looking at EMI, I also noticed an unused custom_ritual dummy, which I've added to the nuke list.