### PR TITLE
Valkyrien Skies Clockwork Compat

### DIFF
--- a/MOD_COMPAT.md
+++ b/MOD_COMPAT.md
@@ -110,6 +110,13 @@
     <td>SC</td>
     <td>Adds extra gauges, for those wanting to take their walls to the next level.</td>
   </tr>
+  <tr>
+    <td><a href="https://www.curseforge.com/minecraft/mc-mods/valkyrien-skies">Valkyrien Skies</a></td>
+    <td>*SC</td>
+    <td><p><b>You must add <code>mixin.ai.poi=false</code> to <code>.minecraft/config/lithium.properties</code>, or the game will crash on world load!</b></p>
+    <p>Adds Create-powered physics contraptions, airships, and boats.</p>
+    <p>Also install the following addon mods: <a href="https://www.curseforge.com/minecraft/mc-mods/create-clockwork">VS: Clockwork</a>, <a href="https://www.curseforge.com/minecraft/mc-mods/valkyrien-sails">Valkyrien Sails</a> (requires <a href="https://www.curseforge.com/minecraft/mc-mods/vlib">VLib</a>), <a href="https://www.curseforge.com/minecraft/mc-mods/create-interactive">Interactive</a>, and <a href="https://www.curseforge.com/minecraft/mc-mods/trackwork">Trackwork</a>.</p></td>
+  </tr>
     <td><p><a href="https://curseforge.com/projects/815548">Integrated Strongholds</a></p></td>
     <td><p>*SC</p></td>
     <td>

--- a/kubejs/server_scripts/server_compatability/vs_clockwork.js
+++ b/kubejs/server_scripts/server_compatability/vs_clockwork.js
@@ -1,0 +1,24 @@
+// Reccomended mods:
+// Valkyrien Skies 2
+// VLib
+// Valkyrien Sails
+// Clockwork
+// Interactive
+// Trackwork
+
+// MUST ADD THIS LINE TO YOUR .MINECRAFT/CONFIG/LITHIUM.PROPERTIES:
+// mixin.ai.poi=false
+// IF YOU DO NOT, THE GAME WILL CRASH ON WORLD LOAD WITH InvalidInjectionException
+if (Platform.isLoaded("vs_clockwork")) {
+    ServerEvents.recipes(event => {
+        event.replaceInput({ mod: "vs_clockwork" }, "vs_clockwork:nyx", "create:precision_mechanism")
+        event.recipes.create.splashing(
+            [Item.of("vs_clockwork:wanderlite_crystal").withChance(0.25)],
+            "minecraft:clay"
+        ).id("kubejs:splashing/wanderlite_crystal_from_clay")
+    })
+
+    ServerEvents.lowPriorityData(event => {
+        removeFeature(event, "vs_clockwork:wanderlite_ore")
+    })
+}

--- a/kubejs/startup_scripts/nukeLists/item.js
+++ b/kubejs/startup_scripts/nukeLists/item.js
@@ -19,6 +19,14 @@ global.itemNukeList = [
     // Balanced Flight
     "balancedflight:ascended_flight_ring",
 
+    // Clockwork
+    "vs_clockwork:asteroid_block",
+    "vs_clockwork:wanderlite_deepslate_ore",
+    "vs_clockwork:wanderlite_end_ore",
+    "vs_clockwork:wanderlite_nyx_ore",
+    "vs_clockwork:nyx",
+    "vs_clockwork:cobbled_nyx",
+
     // Create
     "create:crushed_raw_tin",
     "create:crushed_raw_silver",

--- a/kubejs/startup_scripts/nukeLists/item.js
+++ b/kubejs/startup_scripts/nukeLists/item.js
@@ -24,6 +24,7 @@ global.itemNukeList = [
     "vs_clockwork:wanderlite_deepslate_ore",
     "vs_clockwork:wanderlite_end_ore",
     "vs_clockwork:wanderlite_nyx_ore",
+    "vs_clockwork:charged_nyx",
     "vs_clockwork:nyx",
     "vs_clockwork:cobbled_nyx",
 


### PR DESCRIPTION
Compat patch for Valkyrien Skies Clockwork:

- Removes worldgen of wanderlite (and adds to nukelist), instead obtained via bulk washing Clay
- Nyx is unobtainable in Clockwork, so added to nukelist and use precision mechanisms for the armor.
- Added instructions for compatibility at the top of the compat file:
```
// Reccomended mods:
// Valkyrien Skies 2
// VLib
// Valkyrien Sails
// Clockwork
// Interactive
// Trackwork

// MUST ADD THIS LINE TO YOUR .MINECRAFT/CONFIG/LITHIUM.PROPERTIES:
// mixin.ai.poi=false
// IF YOU DO NOT, THE GAME WILL CRASH ON WORLD LOAD WITH InvalidInjectionException
```

**If you have any suggestions for applying this Lithium config patch dynamically depending on mod load, please let me know.**