### PR TITLE
Fix to Ad-astra Space suit 

### DIFF
--- a/kubejs/server_scripts/key_mods/ad_astra.js
+++ b/kubejs/server_scripts/key_mods/ad_astra.js
@@ -8,6 +8,12 @@ ServerEvents.recipes(event => {
     event.remove({type: "ad_astra:nasa_workbench"})
     event.remove({type: "ad_astra:refining"})
 
+
+    event.remove({type: "minecraft:crafting_shaped", output: "ad_astra:space_helmet"})
+    event.remove({type: "minecraft:crafting_shaped", output: "ad_astra:space_suit"})
+    event.remove({type: "minecraft:crafting_shaped", output: "ad_astra:space_pants"})
+    event.remove({type: "minecraft:crafting_shaped", output: "ad_astra:space_boots"})
+
     event.replaceInput({ id: "ad_astra:ti_69" }, "#forge:plates/steel", "kubejs:matter_plastics")
 })
 

--- a/kubejs/startup_scripts/nukeLists/item.js
+++ b/kubejs/startup_scripts/nukeLists/item.js
@@ -184,7 +184,7 @@ global.itemNukeList = [
     "ad_astra:jet_suit",
     "ad_astra:deepslate_desh_ore",
     "ad_astra:deepslate_ice_shard_ore",
-    /^ad_astra:(space|netherite_space|jet_suit)_(helmet|suit|pants|boots)$/,
+    /^ad_astra:(netherite_space|jet_suit)_(helmet|suit|pants|boots)$/,
     /^ad_astra:(steel|desh|ostrum|calorite)_(tank|engine)$/,
     /ad_astra:.*(mars|venus|mercury|glacio)/,
     /^ad_astra:(?!photovoltaic).*(ostrum|calorite|etrium).*/,


### PR DESCRIPTION
**Describe the PR**
Closes ThePansmith/CABIN#444
The space suit functions as expected on the moon 

**Screenshots**
<img width="850" height="477" alt="Screenshot 2026-08-25 at 10 55 55 AM" src="https://github.com/user-attachments/assets/4d5ed04a-5483-4b6a-b32c-42fd6d101a62" />

**Additional context**

The `nukelist.js` script inside the of `kube_js/server_scripts` calls for `kubejs/startup_scripts\item.js` and seems to to nuke the nbt data of the ad astra space suits items (Listed as "ad_astra:space_helmet", "ad_astra:space_suit" "ad_astra:space_pants", and "ad_astra:space_boots", are hit by the expression `/^ad_astra:(space|netherite_space|jet_suit)_(helmet|suit|pants|boots)$/,`).

I altered this line to say: `/^ad_astra:(netherite_space|jet_suit)_(helmet|suit|pants|boots)$/,`

_Side note: This has the funny side effect of fixing the rendering of the suit on the player character per issue #437, who also directly saw the fix themself, so kudos to them._ 

This change actually causes a runoff problem, it brings back the original ad-astra recipe for the space helmet, space boots, and space leggings without using the mechanical crafter. This was fixed with a removal of all "minecraft:crafting_shaped" recipes inside of `kubejs/server_scripts/key_mods/ad_astra.js` for the items in question (also included in this pull request).
